### PR TITLE
Modify 'MaxWidth' to allow wrapping as well as truncating contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ color = ["papergrid/color", "ansi-cut"]
 tabled_derive = {path = "./tabled_derive"}
 papergrid = "0.1.22"
 ansi-cut = { version = "0.1.0", optional = true }
+unicode-segmentation = "1.8.0"
 
 [dev-dependencies]
 owo-colors = "1"

--- a/examples/width.rs
+++ b/examples/width.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let table = Table::new(&data)
         .with(Style::github_markdown())
-        .with(Modify::new(Full).with(MaxWidth(10, "...")));
+        .with(Modify::new(Full).with(MaxWidth::truncating(10, "...")));
 
     println!("{}", table);
 }

--- a/tests/width_test.rs
+++ b/tests/width_test.rs
@@ -37,7 +37,49 @@ fn max_width() {
 
     let table = Table::new(&data)
         .with(Style::github_markdown())
-        .with(Modify::new(Column(1..).not(Row(..1))).with(MaxWidth(3, "...")))
+        .with(Modify::new(Column(1..).not(Row(..1))).with(MaxWidth::truncating(3, "...")))
+        .to_string();
+
+    assert_eq!(table, expected);
+}
+
+#[test]
+fn max_width_wrapped() {
+    let data = vec![
+        Linux {
+            id: 0,
+            destribution: "Fedora",
+            link: "https://getfedora.org/",
+        },
+        Linux {
+            id: 2,
+            destribution: "OpenSUSE",
+            link: "https://www.opensuse.org/",
+        },
+        Linux {
+            id: 3,
+            destribution: "Endeavouros",
+            link: "https://endeavouros.com/",
+        },
+    ];
+
+    let expected = concat!(
+        "| id | destribution |    link    |\n",
+        "|----+--------------+------------|\n",
+        "| 0  |    Fedora    | https://ge |\n",
+        "|    |              | tfedora.or |\n",
+        "|    |              |     g/     |\n",
+        "| 2  |   OpenSUSE   | https://ww |\n",
+        "|    |              | w.opensuse |\n",
+        "|    |              |   .org/    |\n",
+        "| 3  |  Endeavouro  | https://en |\n",
+        "|    |      s       | deavouros. |\n",
+        "|    |              |    com/    |\n",
+    );
+
+    let table = Table::new(&data)
+        .with(Style::github_markdown())
+        .with(Modify::new(Column(1..).not(Row(..1))).with(MaxWidth::wrapping(10)))
         .to_string();
 
     assert_eq!(table, expected);
@@ -73,7 +115,7 @@ fn dont_change_content_if_width_is_less_then_max_width() {
 
     let table = Table::new(&data)
         .with(Style::github_markdown())
-        .with(Modify::new(Full).with(MaxWidth(1000, "...")))
+        .with(Modify::new(Full).with(MaxWidth::truncating(1000, "...")))
         .to_string();
 
     assert_eq!(table, expected);
@@ -93,7 +135,7 @@ fn max_width_with_emoji() {
 
     let table = Table::new(data)
         .with(Style::github_markdown())
-        .with(Modify::new(Full).with(MaxWidth(3, "...")))
+        .with(Modify::new(Full).with(MaxWidth::truncating(3, "...")))
         .to_string();
 
     assert_eq!(table, _expected);
@@ -120,7 +162,7 @@ fn color_chars_are_stripped() {
 
     let table = Table::new(data)
         .with(Style::github_markdown())
-        .with(Modify::new(Full).with(MaxWidth(3, "...")))
+        .with(Modify::new(Full).with(MaxWidth::truncating(3, "...")))
         .to_string();
 
     println!("{}", table);


### PR DESCRIPTION
Unfortunately this changes the API of `MaxWidth` so that it's constructed using associated functions instead of all the contents being public - perhaps there's a way to do it without that though!

I've pulled in the unicode segmentation crate here to ensure we're not
splitting a string in the middle of a unicode grapheme (see
https://stackoverflow.com/questions/68122526/splitting-a-utf-8-string-into-chunks),
but I'm not sure that's being considered elsewhere in the crate atm -
perhaps this PR should use chars rather than graphemes, and grapheme
consideration can be added in a later PR.

Also this doesn't consider colours - need to think about how that should
be done for the string chunks.