### PR TITLE
tabled/ change style functions to constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A list of ready to use styles.
 Styles can be chosen by passing a `Style` argument option.
 
 ```rust
-let table = Table::new(&data).with(Style::psql());
+let table = Table::new(&data).with(Style::PSQL);
 ```
 
 ### Default
@@ -200,7 +200,7 @@ let table = Table::new(&data).with(Style::psql());
 You can modify existing styles to fits your needs.
 
 ```rust
-let style = tabled::Style::noborder()
+let style = tabled::Style::NO_BORDER
                 .frame_bottom(Some(Line::short('*', ' '')))
                 .split(Some(Line::short(' ', ' ')))
                 .inner(' ');
@@ -226,7 +226,7 @@ The `Format` function provides an interface for a modification of cells.
 
 ```rust
 Table::new(&data)
-    .with(Style::psql()),
+    .with(Style::PSQL),
     .with(Modify::new(Column(..)).with(Format(|s| format!("<< {} >>", s))))
     .with(Modify::new(Row(..1)).with(Format(|s| format!("Head {}", s))));
 ```
@@ -235,7 +235,7 @@ It's also possible to use functions with signature `Fn(&str) -> String` as a for
 
 ```rust
 Table::new(&data)
-    .with(Style::psql()),
+    .with(Style::PSQL),
     .with(Modify::new(Column(..)).with(|s: &str| format!("<< {} >>", s)))
     .with(Modify::new(Row(..1)).with(str::to_lowercase));
 ```
@@ -337,7 +337,7 @@ The library doesn't bind you in usage of any color library but to be able to wor
 
 ```rust
 Table::new(&data)
-    .with(Style::psql())
+    .with(Style::PSQL)
     .with(Modify::new(Column(..1)).with(Format(|s| s.red().to_string())))
     .with(Modify::new(Column(1..2)).with(Format(|s| s.blue().to_string())))
     .with(Modify::new(Column(2..)).with(Format(|s| s.green().to_string())));
@@ -475,7 +475,7 @@ let data = vec![
     (Developer("Maxim Zhiburt"), Domain::Unknown),
 ];
 
-let table = Table::new(data).with(Style::psql()).to_string();
+let table = Table::new(data).with(Style::PSQL).to_string();
 
 assert_eq!(
     table,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -44,7 +44,7 @@ fn main() {
     ];
 
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Modify::new(Head).with(Alignment::Horizontal(AlignmentHorizontal::Center)))
         .with(Modify::new(Row(1..)).with(Alignment::Horizontal(AlignmentHorizontal::Left)));
 

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -48,7 +48,7 @@ fn main() {
     ];
 
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Head).with(Alignment::center_horizontal()))
         .with(Modify::new(Row(1..)).with(Alignment::left()))
         .with(Modify::new(Column(1..2)).with(Format(|s| s.blue().to_string())))

--- a/examples/default_array.rs
+++ b/examples/default_array.rs
@@ -5,7 +5,7 @@ use tabled::{Style, Table};
 
 fn main() {
     let data = matrix::<10>();
-    let table = Table::new(&data).with(Style::pseudo());
+    let table = Table::new(&data).with(Style::PSEUDO);
 
     println!("{}", table);
 }

--- a/examples/format.rs
+++ b/examples/format.rs
@@ -34,7 +34,7 @@ fn main() {
     ];
 
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Row(..1)).with(FormatWithIndex(|_, _, column| column.to_string())))
         .with(Modify::new(Row(1..2).not(Column(..1))).with(FormatFrom(vec!["qwe", "asd"])))
         .with(Modify::new(Column(..1).not(Row(..1))).with(Format(|s| format!("{}...", s))));

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -40,7 +40,7 @@ fn main() {
     ];
 
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Modify::new(Full).with(Indent::new(1, 1, 0, 0)))
         .with(Modify::new(Head).with(Alignment::Horizontal(AlignmentHorizontal::Left)))
         .with(Modify::new(Row(1..)).with(Alignment::Horizontal(AlignmentHorizontal::Center)));

--- a/examples/panel.rs
+++ b/examples/panel.rs
@@ -36,7 +36,7 @@ fn main() {
     let table = Table::new(&data)
         .with(Header("Tabled Releases"))
         .with(Footer(format!("N - {}", data.len())))
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Modify::new(Full).with(Alignment::Horizontal(AlignmentHorizontal::Center)));
 
     println!("{}", table);

--- a/examples/rotate.rs
+++ b/examples/rotate.rs
@@ -28,7 +28,7 @@ fn main() {
 
     let table = Table::new(&data)
         .with(Rotate::Left)
-        .with(Style::noborder())
+        .with(Style::NO_BORDER)
         .with(Modify::new(Full).with(Indent::new(1, 1, 0, 0)));
 
     println!("{}", table);

--- a/examples/width.rs
+++ b/examples/width.rs
@@ -10,7 +10,7 @@ fn main() {
         ["Hello World", "[[[[[[[[[[[[[[[[["],
     ];
 
-    let table = Table::new(&data).with(Style::github_markdown()).with(
+    let table = Table::new(&data).with(Style::GITHUB_MARKDOWN).with(
         Modify::new(Full)
             .with(MaxWidth::truncating(10, "..."))
             .with(Alignment::left()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@
 //!     (Developer("Maxim Zhiburt"), Domain::Unknown),
 //! ];
 //!     
-//! let table = Table::new(data).with(Style::psql()).to_string();
+//! let table = Table::new(data).with(Style::PSQL).to_string();
 //!
 //! assert_eq!(
 //!     table,
@@ -235,7 +235,7 @@ pub trait CellOption {
 /// use tabled::{Table, Style, Alignment, Full, Modify};
 /// let data = vec!["Hello", "2021"];
 /// let table = Table::new(&data)
-///                 .with(Style::psql())
+///                 .with(Style::PSQL)
 ///                 .with(Modify::new(Full).with(Alignment::left()));
 /// println!("{}", table);
 /// ```
@@ -249,7 +249,7 @@ impl Table {
         let grid = build_grid(iter);
 
         let table = Self { grid };
-        table.with(Style::ascii())
+        table.with(Style::ASCII)
     }
 
     /// With is a generic function which applies options to the [Table].

--- a/src/style.rs
+++ b/src/style.rs
@@ -11,7 +11,7 @@ use papergrid::{Border, Entity, Grid, Settings};
 /// use tabled::{Table, Style, style::Line};
 /// let data = vec!["Hello", "2021"];
 /// let table = Table::new(&data).with(
-///                 Style::noborder()
+///                 Style::NO_BORDER
 ///                     .frame_bottom(Some(Line::short('*', ' ')))
 ///                     .split(Some(Line::short('*', ' ')))
 ///                     .inner(' ')
@@ -41,39 +41,17 @@ impl Style {
     ///     | 3  | Endeavouros  | https://endeavouros.com/  |
     ///     +----+--------------+---------------------------+
     /// ```
-    #[deprecated(note = "The name is not explicit. Use ascii function instead.")]
-    pub fn default() -> Self {
-        Self::ascii()
-    }
-
-    /// Ascii style looks like the following table
-    ///
-    /// ```text
-    ///     +----+--------------+---------------------------+
-    ///     | id | destribution |           link            |
-    ///     +----+--------------+---------------------------+
-    ///     | 0  |    Fedora    |  https://getfedora.org/   |
-    ///     +----+--------------+---------------------------+
-    ///     | 2  |   OpenSUSE   | https://www.opensuse.org/ |
-    ///     +----+--------------+---------------------------+
-    ///     | 3  | Endeavouros  | https://endeavouros.com/  |
-    ///     +----+--------------+---------------------------+
-    /// ```
-    pub fn ascii() -> Self {
-        let line = Line::bordered('-', '+', '+', '+');
-
-        Self::new(
-            Frame {
-                bottom: Some(line.clone()),
-                top: Some(line.clone()),
-                left: Some('|'),
-                right: Some('|'),
-            },
-            Some(line.clone()),
-            Some(line),
-            '|',
-        )
-    }
+    pub const ASCII: Self = Self::new(
+        Frame {
+            bottom: Some(Line::bordered('-', '+', '+', '+')),
+            top: Some(Line::bordered('-', '+', '+', '+')),
+            left: Some('|'),
+            right: Some('|'),
+        },
+        Some(Line::bordered('-', '+', '+', '+')),
+        Some(Line::bordered('-', '+', '+', '+')),
+        '|',
+    );
 
     /// Noborder style looks like the following table
     ///
@@ -83,9 +61,7 @@ impl Style {
     ///      2      OpenSUSE     https://www.opensuse.org/
     ///      3    Endeavouros    https://endeavouros.com/
     /// ```
-    pub fn noborder() -> Self {
-        Self::new(Frame::default(), None, None, ' ')
-    }
+    pub const NO_BORDER: Self = Self::new(Frame::empty(), None, None, ' ');
 
     /// Psql style looks like the following table
     ///
@@ -96,9 +72,7 @@ impl Style {
     ///      2  |   OpenSUSE   | https://www.opensuse.org/
     ///      3  | Endeavouros  | https://endeavouros.com/
     /// ```
-    pub fn psql() -> Self {
-        Self::new(Frame::default(), Some(Line::short('-', '+')), None, '|')
-    }
+    pub const PSQL: Self = Self::new(Frame::empty(), Some(Line::short('-', '+')), None, '|');
 
     /// Github_markdown style looks like the following table
     ///
@@ -109,18 +83,18 @@ impl Style {
     ///     | 2  |   OpenSUSE   | https://www.opensuse.org/ |
     ///     | 3  | Endeavouros  | https://endeavouros.com/  |
     /// ```
-    pub fn github_markdown() -> Self {
-        Self::new(
-            Frame {
-                left: Some('|'),
-                right: Some('|'),
-                ..Default::default()
-            },
-            Some(Line::bordered('-', '+', '|', '|')),
-            None,
-            '|',
-        )
-    }
+    pub const GITHUB_MARKDOWN: Self = Self::new(
+        Frame {
+            left: Some('|'),
+            right: Some('|'),
+            bottom: None,
+            top: None,
+        },
+        Some(Line::bordered('-', '+', '|', '|')),
+        None,
+        '|',
+    );
+
     /// Pseudo style looks like the following table
     ///
     /// ```text
@@ -134,19 +108,17 @@ impl Style {
     ///     │ 3  │ Endeavouros  │ https://endeavouros.com/  │
     ///     └────┴──────────────┴───────────────────────────┘
     /// ```
-    pub fn pseudo() -> Self {
-        Self::new(
-            Frame {
-                left: Some('│'),
-                right: Some('│'),
-                bottom: Some(Line::bordered('─', '┴', '└', '┘')),
-                top: Some(Line::bordered('─', '┬', '┌', '┐')),
-            },
-            Some(Line::bordered('─', '┼', '├', '┤')),
-            Some(Line::bordered('─', '┼', '├', '┤')),
-            '│',
-        )
-    }
+    pub const PSEUDO: Self = Self::new(
+        Frame {
+            left: Some('│'),
+            right: Some('│'),
+            bottom: Some(Line::bordered('─', '┴', '└', '┘')),
+            top: Some(Line::bordered('─', '┬', '┌', '┐')),
+        },
+        Some(Line::bordered('─', '┼', '├', '┤')),
+        Some(Line::bordered('─', '┼', '├', '┤')),
+        '│',
+    );
 
     /// Pseudo_clean style looks like the following table
     ///
@@ -159,10 +131,51 @@ impl Style {
     ///     │ 3  │ Endeavouros  │ https://endeavouros.com/  │
     ///     └────┴──────────────┴───────────────────────────┘
     /// ```
+    pub const PSEUDO_CLEAN: Self = Self::new(
+        Frame {
+            left: Some('│'),
+            right: Some('│'),
+            bottom: Some(Line::bordered('─', '┴', '└', '┘')),
+            top: Some(Line::bordered('─', '┬', '┌', '┐')),
+        },
+        Some(Line::bordered('─', '┼', '├', '┤')),
+        None,
+        '│',
+    );
+
+    #[deprecated(note = "The name is not explicit. Use ASCII constant instead.")]
+    pub fn default() -> Self {
+        Self::ASCII
+    }
+
+    #[deprecated(note = "The name is not explicit. Use ASCII constant instead.")]
+    pub fn ascii() -> Self {
+        Self::ASCII
+    }
+
+    #[deprecated(note = "The name is not explicit. Use NO_BORDER constant instead.")]
+    pub fn noborder() -> Self {
+        Self::NO_BORDER
+    }
+
+    #[deprecated(note = "The name is not explicit. Use PSQL constant instead.")]
+    pub fn psql() -> Self {
+        Self::PSQL
+    }
+
+    #[deprecated(note = "The name is not explicit. Use GITHUB_MARKDOWN constant instead.")]
+    pub fn github_markdown() -> Self {
+        Self::GITHUB_MARKDOWN
+    }
+
+    #[deprecated(note = "The name is not explicit. Use PSEUDO constant instead.")]
+    pub fn pseudo() -> Self {
+        Self::PSEUDO
+    }
+
+    #[deprecated(note = "The name is not explicit. Use PSEUDO_CLEAN constant instead.")]
     pub fn pseudo_clean() -> Self {
-        let mut pseudo = Self::pseudo();
-        pseudo.split = None;
-        pseudo
+        Self::PSEUDO_CLEAN
     }
 
     /// Left frame character.
@@ -214,7 +227,7 @@ impl Style {
         self
     }
 
-    fn new(frame: Frame, header: Option<Line>, split: Option<Line>, inner: char) -> Self {
+    const fn new(frame: Frame, header: Option<Line>, split: Option<Line>, inner: char) -> Self {
         Self {
             frame,
             split,
@@ -235,7 +248,7 @@ pub struct Line {
 
 impl Line {
     /// A line for frame styles.
-    pub fn bordered(main: char, intersection: char, left: char, right: char) -> Self {
+    pub const fn bordered(main: char, intersection: char, left: char, right: char) -> Self {
         Self {
             intersection,
             main,
@@ -245,11 +258,12 @@ impl Line {
     }
 
     /// A line for no-frame styles.
-    pub fn short(main: char, intersection: char) -> Self {
+    pub const fn short(main: char, intersection: char) -> Self {
         Self {
             main,
             intersection,
-            ..Default::default()
+            left_corner: None,
+            right_corner: None,
         }
     }
 }
@@ -260,6 +274,17 @@ struct Frame {
     bottom: Option<Line>,
     left: Option<char>,
     right: Option<char>,
+}
+
+impl Frame {
+    const fn empty() -> Self {
+        Self {
+            bottom: None,
+            top: None,
+            left: None,
+            right: None,
+        }
+    }
 }
 
 impl TableOption for Style {

--- a/src/width.rs
+++ b/src/width.rs
@@ -15,7 +15,7 @@ use papergrid::{Entity, Grid, Settings};
 /// ];
 ///
 /// let table = Table::new(&data)
-///     .with(Style::github_markdown())
+///     .with(Style::GITHUB_MARKDOWN)
 ///     .with(Modify::new(Full).with(MaxWidth::truncating(5, "...")));
 /// ```
 ///

--- a/tests/alignment_test.rs
+++ b/tests/alignment_test.rs
@@ -7,7 +7,7 @@ mod util;
 fn full_alignment() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Alignment::left()))
         .to_string();
 
@@ -26,7 +26,7 @@ fn full_alignment() {
 fn head_and_data_alignment() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::ascii())
+        .with(Style::ASCII)
         .with(Modify::new(Head).with(Alignment::left()))
         .with(Modify::new(Row(1..)).with(Alignment::right()))
         .to_string();
@@ -65,7 +65,7 @@ fn full_alignment_multiline() {
     );
 
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Alignment::left()))
         .to_string();
 
@@ -80,7 +80,7 @@ fn vertical_alignment_test() {
     data[2][3] = String::from("https://\nwww\n.\nredhat\n.com\n/en");
 
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Column(1..)).with(Alignment::bottom()))
         .to_string();
 
@@ -116,7 +116,7 @@ fn alignment_doesnt_change_indent() {
     );
 
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Indent::new(3, 0, 0, 0)))
         .with(Modify::new(Full).with(Alignment::left()))
         .to_string();

--- a/tests/disable_test.rs
+++ b/tests/disable_test.rs
@@ -7,7 +7,7 @@ mod util;
 fn disable_rows() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::ascii())
+        .with(Style::ASCII)
         .with(Modify::new(Full).with(Alignment::left()))
         .with(Disable::Row(1..=2))
         .to_string();
@@ -27,7 +27,7 @@ fn disable_rows() {
 fn disable_header() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Alignment::left()))
         .with(Disable::Row(..1))
         .to_string();
@@ -46,7 +46,7 @@ fn disable_header() {
 fn disable_all_table_via_rows() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Alignment::left()))
         .with(Disable::Row(..))
         .to_string();
@@ -60,7 +60,7 @@ fn disable_header_with_new_styling() {
     let table = Table::new(&data)
         .with(Modify::new(Full).with(Alignment::left()))
         .with(Disable::Row(..1))
-        .with(Style::pseudo_clean())
+        .with(Style::PSEUDO_CLEAN)
         .to_string();
 
     let expected = concat!(
@@ -79,7 +79,7 @@ fn disable_header_with_new_styling() {
 fn disable_columns() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Disable::Column(..1))
         .to_string();
 
@@ -98,7 +98,7 @@ fn disable_columns() {
 fn disable_all_table_via_columns() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Alignment::left()))
         .with(Disable::Column(..))
         .to_string();

--- a/tests/format_test.rs
+++ b/tests/format_test.rs
@@ -32,7 +32,7 @@ fn formatting_full_test() {
 fn formatting_head_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Head).with(Format(|s| format!(":{}", s))))
         .to_string();
 
@@ -51,7 +51,7 @@ fn formatting_head_test() {
 fn formatting_row_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Row(1..)).with(Format(|s| format!("<{}>", s))))
         .to_string();
 
@@ -70,7 +70,7 @@ fn formatting_row_test() {
 fn formatting_column_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Column(..1)).with(Format(|s| format!("(x) {}", s))))
         .to_string();
     let expected = concat!(
@@ -91,7 +91,7 @@ fn formatting_multiline_test() {
     data[2][3] = String::from("https://\nwww\n.\nredhat\n.com\n/en");
 
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Format(multiline(|s| format!("(x) {}", s)))))
         .to_string();
 
@@ -118,7 +118,7 @@ fn formatting_multiline_test() {
 fn formatting_cell_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Cell(0, 0)).with(Format(|s| format!("(x) {}", s))))
         .with(Modify::new(Cell(0, 1)).with(Format(|s| format!("(x) {}", s))))
         .with(Modify::new(Cell(0, 2)).with(Format(|s| format!("(x) {}", s))))
@@ -139,7 +139,7 @@ fn formatting_cell_test() {
 fn formatting_and_combination_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Column(..1).and(Row(..1))).with(Format(|s| format!("(x) {}", s))))
         .to_string();
 
@@ -158,7 +158,7 @@ fn formatting_and_combination_test() {
 fn formatting_not_combination_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(
             Modify::new(Column(..1).and(Row(..1)).not(Cell(0, 0)))
                 .with(Format(|s| format!("(x) {}", s))),
@@ -180,7 +180,7 @@ fn formatting_not_combination_test() {
 fn formatting_using_lambda_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Head).with(|s: &str| format!(":{}", s)))
         .to_string();
 
@@ -199,7 +199,7 @@ fn formatting_using_lambda_test() {
 fn formatting_using_function_test() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Head).with(str::to_uppercase))
         .to_string();
 
@@ -218,7 +218,7 @@ fn formatting_using_function_test() {
 fn format_from() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Head).with(FormatFrom(vec![
             "Header Name 1",
             "Header Name 2",
@@ -241,7 +241,7 @@ fn format_from() {
 fn format_with_index() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(
             Modify::new(Head).with(FormatWithIndex(|a, b, c| match (b, c) {
                 (0, 0) => "(0, 0)".to_string(),
@@ -273,7 +273,7 @@ mod color {
     fn color_column_test() {
         let data = create_vector::<3, 3>();
         let table = Table::new(&data)
-            .with(Style::psql())
+            .with(Style::PSQL)
             .with(Modify::new(Column(..1).and(Column(2..))).with(Format(|s| s.red().to_string())))
             .with(Modify::new(Column(1..2)).with(Format(|s| s.blue().to_string())))
             .to_string();
@@ -297,7 +297,7 @@ mod color {
         data[2][3] = String::from("https://\nwww\n.\nredhat\n.com\n/en");
 
         let table = Table::new(&data)
-            .with(Style::psql())
+            .with(Style::PSQL)
             .with(Modify::new(Column(..1)).with(Format(multiline(|s| s.red().to_string()))))
             .with(Modify::new(Column(1..2)).with(Format(multiline(|s| s.blue().to_string()))))
             .with(Modify::new(Column(2..)).with(Format(multiline(|s| s.green().to_string()))))

--- a/tests/highlingt_test.rs
+++ b/tests/highlingt_test.rs
@@ -7,7 +7,7 @@ mod util;
 fn highlingt_cell() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Highlight::cell(
             0,
             0,
@@ -39,7 +39,7 @@ fn highlingt_cell() {
 fn highlingt_row() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Highlight::row(
             0,
             Border::full('+', '+', '+', '+', '+', '+', '+', '+'),
@@ -69,7 +69,7 @@ fn highlingt_row() {
 fn highlingt_column() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Highlight::column(
             0,
             Border::full('+', '+', '+', '+', '+', '+', '+', '+'),
@@ -99,7 +99,7 @@ fn highlingt_column() {
 fn highlingt_row_range() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Highlight::row_range(
             1,
             3,
@@ -126,7 +126,7 @@ fn highlingt_row_range() {
 fn highlingt_column_range() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Highlight::column_range(
             0,
             2,
@@ -153,7 +153,7 @@ fn highlingt_column_range() {
 fn highlingt_frame() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo())
+        .with(Style::PSEUDO)
         .with(Highlight::frame(Border::full(
             '+', '+', '+', '+', '+', '+', '+', '+',
         )))

--- a/tests/indent_test.rs
+++ b/tests/indent_test.rs
@@ -7,7 +7,7 @@ mod util;
 fn indent() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Full).with(Alignment::left()))
         .with(Modify::new(Row(1..)).with(Indent::new(1, 1, 0, 2)))
         .to_string();
@@ -33,7 +33,7 @@ fn indent() {
 fn indent_multiline() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Row(1..)).with(Indent::new(1, 1, 1, 1)))
         .to_string();
 
@@ -58,7 +58,7 @@ fn indent_multiline() {
 fn indent_multiline_with_vertical_alignment() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(
             Modify::new(Full)
                 .with(Alignment::center_horizontal())

--- a/tests/panel_test.rs
+++ b/tests/panel_test.rs
@@ -8,7 +8,7 @@ mod util;
 #[test]
 fn panel_has_no_style_by_default() {
     let table = Table::new(create_vector::<3, 3>())
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Panel("Linux Distributions", 0))
         .to_string();
 
@@ -30,7 +30,7 @@ fn panel_has_no_style_by_default() {
 fn highligt_panel() {
     let table = Table::new(create_vector::<3, 3>())
         .with(Panel("Linux Distributions", 0))
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Highlight::cell(
             0,
             0,
@@ -58,7 +58,7 @@ fn top_panel() {
     let table = Table::new(create_vector::<3, 3>())
         .with(Panel("Linux Distributions", 0))
         .with(Modify::new(Full).with(Alignment::center_horizontal()))
-        .with(Style::psql())
+        .with(Style::PSQL)
         .to_string();
 
     let expected = concat!(
@@ -79,7 +79,7 @@ fn bottom_panel() {
     let table = Table::new(&data)
         .with(Panel("Linux Distributions", data.len() + 1))
         .with(Modify::new(Row(data.len() + 1..)).with(Alignment::center_horizontal()))
-        .with(Style::psql())
+        .with(Style::PSQL)
         .to_string();
 
     let expected = concat!(
@@ -99,7 +99,7 @@ fn inner_panel() {
     let table = Table::new(create_vector::<3, 3>())
         .with(Panel("Linux Distributions", 2))
         .with(Modify::new(Row(2..)).with(Alignment::center_horizontal()))
-        .with(Style::psql())
+        .with(Style::PSQL)
         .to_string();
 
     let expected = concat!(
@@ -118,7 +118,7 @@ fn inner_panel() {
 fn header() {
     let table = Table::new(create_vector::<3, 3>())
         .with(Header("Linux Distributions"))
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Row(0..1)).with(Alignment::center_horizontal()))
         .to_string();
 
@@ -140,7 +140,7 @@ fn footer() {
     let table = Table::new(&data)
         .with(Header("Linux Distributions"))
         .with(Footer("The end"))
-        .with(Style::psql())
+        .with(Style::PSQL)
         .with(Modify::new(Row(0..1).and(Row(data.len()..))).with(Alignment::center_horizontal()))
         .to_string();
 

--- a/tests/rotate_test.rs
+++ b/tests/rotate_test.rs
@@ -155,7 +155,7 @@ fn rotate_preserve_border_styles_test() {
     let data = [(123, 456, 789), (234, 567, 891), (111, 222, 333)];
 
     let table = Table::new(&data)
-        .with(Style::ascii())
+        .with(Style::ASCII)
         .with(Highlight::row(0, Border::default().top('*')))
         .with(Rotate::Left)
         .to_string();
@@ -174,7 +174,7 @@ fn rotate_preserve_border_styles_test() {
     );
 
     let table = Table::new(&data)
-        .with(Style::ascii())
+        .with(Style::ASCII)
         .with(Highlight::cell(0, 2, Border::default().bottom('*')))
         .with(Rotate::Left)
         .to_string();

--- a/tests/style_test.rs
+++ b/tests/style_test.rs
@@ -7,7 +7,7 @@ mod util;
 #[test]
 fn default_style() {
     let data = create_vector::<3, 3>();
-    let table = Table::new(&data).with(Style::ascii()).to_string();
+    let table = Table::new(&data).with(Style::ASCII).to_string();
 
     let expected = concat!(
         "+---+----------+----------+----------+\n",
@@ -27,7 +27,7 @@ fn default_style() {
 #[test]
 fn psql_style() {
     let data = create_vector::<3, 3>();
-    let table = Table::new(&data).with(Style::psql()).to_string();
+    let table = Table::new(&data).with(Style::PSQL).to_string();
 
     let expected = concat!(
         " N | column 0 | column 1 | column 2 \n",
@@ -43,7 +43,7 @@ fn psql_style() {
 #[test]
 fn github_markdown_style() {
     let data = create_vector::<3, 3>();
-    let table = Table::new(&data).with(Style::github_markdown()).to_string();
+    let table = Table::new(&data).with(Style::GITHUB_MARKDOWN).to_string();
 
     let expected = concat!(
         "| N | column 0 | column 1 | column 2 |\n",
@@ -59,7 +59,7 @@ fn github_markdown_style() {
 #[test]
 fn pseudo_style() {
     let data = create_vector::<3, 3>();
-    let table = Table::new(&data).with(Style::pseudo()).to_string();
+    let table = Table::new(&data).with(Style::PSEUDO).to_string();
 
     let expected = concat!(
         "┌───┬──────────┬──────────┬──────────┐\n",
@@ -79,7 +79,7 @@ fn pseudo_style() {
 #[test]
 fn pseudo_clean_style() {
     let data = create_vector::<3, 3>();
-    let table = Table::new(&data).with(Style::pseudo_clean()).to_string();
+    let table = Table::new(&data).with(Style::PSEUDO_CLEAN).to_string();
 
     let expected = concat!(
         "┌───┬──────────┬──────────┬──────────┐\n",
@@ -97,7 +97,7 @@ fn pseudo_clean_style() {
 #[test]
 fn noborder_style() {
     let data = create_vector::<3, 3>();
-    let table = Table::new(&data).with(Style::noborder()).to_string();
+    let table = Table::new(&data).with(Style::NO_BORDER).to_string();
 
     let expected = concat!(
         " N   column 0   column 1   column 2 \n",
@@ -113,7 +113,7 @@ fn noborder_style() {
 fn style_head_changes() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo_clean().header(None))
+        .with(Style::PSEUDO_CLEAN.header(None))
         .to_string();
 
     let expected = concat!(
@@ -132,7 +132,7 @@ fn style_head_changes() {
 fn style_frame_changes() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::pseudo_clean().frame_bottom(None).frame_top(None))
+        .with(Style::PSEUDO_CLEAN.frame_bottom(None).frame_top(None))
         .to_string();
 
     let expected = concat!(
@@ -151,7 +151,7 @@ fn custom_style() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
         .with(
-            Style::noborder()
+            Style::NO_BORDER
                 .frame_bottom(Some(Line::short('*', '\'')))
                 .split(Some(Line::short('`', '\'')))
                 .inner('\''),

--- a/tests/table_test.rs
+++ b/tests/table_test.rs
@@ -721,7 +721,7 @@ fn tuple_combination() {
         (Developer("Maxim Zhiburt"), Domain::Unknown),
     ];
 
-    let table = Table::new(data).with(Style::psql()).to_string();
+    let table = Table::new(data).with(Style::PSQL).to_string();
 
     assert_eq!(
         table,

--- a/tests/width_test.rs
+++ b/tests/width_test.rs
@@ -7,7 +7,7 @@ mod util;
 fn max_width() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Column(1..).not(Row(..1))).with(MaxWidth::truncating(2, "...")))
         .to_string();
 
@@ -26,7 +26,7 @@ fn max_width() {
 fn max_width_wrapped() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Column(1..).not(Row(..1))).with(MaxWidth::wrapping(2)))
         .to_string();
 
@@ -70,7 +70,7 @@ fn max_width_wrapped_collored() {
     );
 
     let table = Table::new(data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Full).with(MaxWidth::wrapping(2)))
         .to_string();
 
@@ -83,7 +83,7 @@ fn max_width_wrapped_collored() {
 fn dont_change_content_if_width_is_less_then_max_width() {
     let data = create_vector::<3, 3>();
     let table = Table::new(&data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Full).with(MaxWidth::truncating(1000, "...")))
         .to_string();
 
@@ -111,7 +111,7 @@ fn max_width_with_emoji() {
     );
 
     let table = Table::new(data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Full).with(MaxWidth::truncating(3, "...")))
         .to_string();
 
@@ -138,7 +138,7 @@ fn color_chars_are_stripped() {
     );
 
     let table = Table::new(data)
-        .with(Style::github_markdown())
+        .with(Style::GITHUB_MARKDOWN)
         .with(Modify::new(Full).with(MaxWidth::truncating(3, "...")))
         .to_string();
 


### PR DESCRIPTION
Removing deprecated functions will be a breaking change.
So probably then the library must bump version to `1.0.0`