### PR TITLE
Switch from String backend to Cow<str>

### DIFF
--- a/papergrid/src/lib.rs
+++ b/papergrid/src/lib.rs
@@ -23,6 +23,7 @@
 //! ```
 
 use std::{
+    borrow::Cow,
     cmp::max,
     collections::HashMap,
     fmt::{self, Display},
@@ -45,14 +46,14 @@ const DEFAULT_SPLIT_BORDER_CHAR: char = ' ';
 const DEFAULT_SPLIT_INTERSECTION_CHAR: char = ' ';
 
 /// Grid provides a set of methods for building a text-based table
-pub struct Grid {
+pub struct Grid<'a> {
     size: (usize, usize),
     styles: HashMap<Entity, Style>,
-    cells: Vec<Vec<String>>,
+    cells: Vec<Vec<Cow<'a, str>>>,
     borders: Borders,
 }
 
-impl Grid {
+impl<'a> Grid<'a> {
     /// The new method creates a grid instance with default styles.
     ///
     /// The size of the grid can not be changed after the instance is created.
@@ -79,7 +80,7 @@ impl Grid {
 
         Grid {
             size: (rows, columns),
-            cells: vec![vec![String::new(); columns]; rows],
+            cells: vec![vec![Cow::Borrowed(""); columns]; rows],
             styles,
             borders: Borders::new(rows, columns),
         }
@@ -286,7 +287,7 @@ impl Grid {
         let border = self.borders.get_border(row, column).unwrap();
 
         Settings::default()
-            .text(content)
+            .text(content.to_owned())
             .alignment(style.alignment_h)
             .vertical_alignment(style.alignment_v)
             .span(style.span)
@@ -339,7 +340,7 @@ impl Grid {
 
     /// get_cell_content returns content without any style changes
     pub fn get_cell_content(&mut self, row: usize, column: usize) -> &str {
-        self.cells[row][column].as_str()
+        self.cells[row][column].as_ref()
     }
 
     /// Count_rows returns an amount of rows on the grid
@@ -352,7 +353,7 @@ impl Grid {
         self.size.1
     }
 
-    pub fn set_text<S: Into<String>>(&mut self, entity: &Entity, text: S) {
+    pub fn set_text<S: Into<Cow<'a, str>>>(&mut self, entity: &Entity, text: S) {
         let text = text.into();
         match *entity {
             Entity::Cell(row, column) => {
@@ -805,7 +806,7 @@ impl Settings {
     }
 }
 
-impl std::fmt::Display for Grid {
+impl std::fmt::Display for Grid<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let count_rows = self.count_rows();
         let count_columns = self.count_columns();

--- a/papergrid/tests/extract.rs
+++ b/papergrid/tests/extract.rs
@@ -92,7 +92,7 @@ fn extract_empty_test() {
     assert_eq!(grid.to_string(), "");
 }
 
-fn new_grid<const N_ROWS: usize, const N_COLUMNS: usize>() -> Grid {
+fn new_grid<const N_ROWS: usize, const N_COLUMNS: usize>() -> Grid<'static> {
     let mut grid = Grid::new(N_ROWS, N_COLUMNS);
 
     for row in 0..N_ROWS {

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -1,6 +1,8 @@
 use tabled::Tabled;
 
 mod tupple_structure {
+    use std::borrow::Cow;
+
     use super::*;
 
     #[test]
@@ -110,9 +112,16 @@ mod tupple_structure {
         #[derive(Tabled)]
         struct St<T: std::fmt::Display>(T);
 
-        fn infer_type<T: std::fmt::Display>(v: T) -> (Vec<String>, Vec<String>) {
+        fn infer_type<T: std::fmt::Display>(
+            v: T,
+        ) -> (Vec<Cow<'static, str>>, Vec<Cow<'static, str>>) {
             let st = St(v);
-            (<St<T> as Tabled>::headers(), st.fields())
+            let mut fields = Vec::new();
+            for field in st.fields().iter() {
+                fields.push(Cow::Owned(field.to_lowercase()));
+            }
+
+            (<St<T> as Tabled>::headers(), fields)
         }
 
         let (headers, fields) = infer_type(1);

--- a/tests/expanded_display_test.rs
+++ b/tests/expanded_display_test.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::util::create_vector;
 use tabled::{display::ExpandedDisplay, Tabled};
 
@@ -39,14 +41,14 @@ fn display_colored() {
     data[0][2] = "https://getfedora.org/"
         .red()
         .on_color(AnsiColors::Blue)
-        .to_string();
+        .into();
     data[1][2] = "https://www.opensuse.org/"
         .green()
         .on_color(AnsiColors::Black)
-        .to_string();
-    data[2][2] = "https://endeavouros.com/".blue().underline().to_string();
+        .into();
+    data[2][2] = "https://endeavouros.com/".blue().underline().into();
 
-    let table = ExpandedDisplay::new(&data).to_string();
+    let table = ExpandedDisplay::new(&data);
 
     let expected = concat!(
         "-[ RECORD 0 ]-----------------------\n",
@@ -74,11 +76,11 @@ fn display_empty() {
     struct Type;
 
     impl Tabled for Type {
-        fn fields(&self) -> Vec<String> {
+        fn fields(&self) -> Vec<Cow<'_, str>> {
             Vec::new()
         }
 
-        fn headers() -> Vec<String> {
+        fn headers() -> Vec<Cow<'static, str>> {
             Vec::new()
         }
     }
@@ -94,12 +96,12 @@ fn display_dynamic_header_template() {
         struct Type;
 
         impl Tabled for Type {
-            fn fields(&self) -> Vec<String> {
-                vec!["He".to_string(), "123".to_string(), "asd".to_string()]
+            fn fields(&self) -> Vec<Cow<'_, str>> {
+                vec!["He".into(), "123".into(), "asd".into()]
             }
 
-            fn headers() -> Vec<String> {
-                vec!["1".to_string(), "2".to_string(), "3".to_string()]
+            fn headers() -> Vec<Cow<'static, str>> {
+                vec!["1".into(), "2".into(), "3".into()]
             }
         }
 
@@ -113,12 +115,12 @@ fn display_dynamic_header_template() {
         struct Type;
 
         impl Tabled for Type {
-            fn fields(&self) -> Vec<String> {
-                vec!["He".to_string(), "123".to_string(), "asd".to_string()]
+            fn fields(&self) -> Vec<Cow<'_, str>> {
+                vec!["He".into(), "123".into(), "asd".into()]
             }
 
-            fn headers() -> Vec<String> {
-                vec!["11".to_string(), "2222222".to_string(), "3".to_string()]
+            fn headers() -> Vec<Cow<'static, str>> {
+                vec!["11".into(), "2222222".into(), "3".into()]
             }
         }
 
@@ -137,12 +139,12 @@ fn display_dynamic_header_template() {
         struct Type;
 
         impl Tabled for Type {
-            fn fields(&self) -> Vec<String> {
-                vec!["HeheHehe".to_string(), "123".to_string(), "asd".to_string()]
+            fn fields(&self) -> Vec<Cow<'_, str>> {
+                vec!["HeheHehe".into(), "123".into(), "asd".into()]
             }
 
-            fn headers() -> Vec<String> {
-                vec!["11".to_string(), "2222222".to_string(), "3".to_string()]
+            fn headers() -> Vec<Cow<'static, str>> {
+                vec!["11".into(), "2222222".into(), "3".into()]
             }
         }
 
@@ -161,12 +163,12 @@ fn display_dynamic_header_template() {
         struct Type;
 
         impl Tabled for Type {
-            fn fields(&self) -> Vec<String> {
-                vec!["He".to_string(), "123".to_string(), "asd".to_string()]
+            fn fields(&self) -> Vec<Cow<'_, str>> {
+                vec!["He".into(), "123".into(), "asd".into()]
             }
 
-            fn headers() -> Vec<String> {
-                vec!["11111111111".to_string(), "2".to_string(), "3".to_string()]
+            fn headers() -> Vec<Cow<'static, str>> {
+                vec!["11111111111".into(), "2".into(), "3".into()]
             }
         }
 
@@ -185,16 +187,12 @@ fn display_dynamic_header_template() {
         struct Type;
 
         impl Tabled for Type {
-            fn fields(&self) -> Vec<String> {
-                vec!["He".to_string(), "123".to_string(), "asd".to_string()]
+            fn fields(&self) -> Vec<Cow<'_, str>> {
+                vec!["He".into(), "123".into(), "asd".into()]
             }
 
-            fn headers() -> Vec<String> {
-                vec![
-                    "1111111111111".to_string(),
-                    "2".to_string(),
-                    "3".to_string(),
-                ]
+            fn headers() -> Vec<Cow<'static, str>> {
+                vec!["1111111111111".into(), "2".into(), "3".into()]
             }
         }
 
@@ -213,15 +211,15 @@ fn display_dynamic_header_template() {
         struct Type;
 
         impl Tabled for Type {
-            fn fields(&self) -> Vec<String> {
-                vec!["He".to_string(), "123".to_string(), "asd".to_string()]
+            fn fields(&self) -> Vec<Cow<'_, str>> {
+                vec!["He".into(), "123".into(), "asd".into()]
             }
 
-            fn headers() -> Vec<String> {
+            fn headers() -> Vec<Cow<'static, str>> {
                 vec![
-                    "11111111111111111111111111111".to_string(),
-                    "2".to_string(),
-                    "3".to_string(),
+                    "11111111111111111111111111111".into(),
+                    "2".into(),
+                    "3".into(),
                 ]
             }
         }
@@ -242,12 +240,12 @@ fn display_dynamic_header_template() {
         struct Type;
 
         impl Tabled for Type {
-            fn fields(&self) -> Vec<String> {
-                vec!["22".to_string()]
+            fn fields(&self) -> Vec<Cow<'_, str>> {
+                vec!["22".into()]
             }
 
-            fn headers() -> Vec<String> {
-                vec!["11111111111".to_string()]
+            fn headers() -> Vec<Cow<'static, str>> {
+                vec!["11111111111".into()]
             }
         }
 
@@ -287,16 +285,12 @@ fn display_multiline_field() {
     struct St;
 
     impl Tabled for St {
-        fn fields(&self) -> Vec<String> {
-            vec!["1".to_string(), "2".to_string(), "3".to_string()]
+        fn fields(&self) -> Vec<Cow<'_, str>> {
+            vec!["1".into(), "2".into(), "3".into()]
         }
 
-        fn headers() -> Vec<String> {
-            vec![
-                "Hello\nWorld".to_string(),
-                "123".to_string(),
-                "asd".to_string(),
-            ]
+        fn headers() -> Vec<Cow<'static, str>> {
+            vec!["Hello\nWorld".into(), "123".into(), "asd".into()]
         }
     }
 
@@ -316,9 +310,9 @@ fn display_multiline_field() {
 #[test]
 fn display_multiline_record_value() {
     let mut data = create_vector::<2, 3>();
-    data[0][0] = "Hello\nWorld".to_string();
-    data[0][1] = "123".to_string();
-    data[0][2] = "asd".to_string();
+    data[0][0] = "Hello\nWorld".into();
+    data[0][1] = "123".into();
+    data[0][2] = "asd".into();
 
     let table = ExpandedDisplay::new(&data).to_string();
 
@@ -399,9 +393,9 @@ fn display_with_formatter() {
 #[test]
 fn display_with_one_line_formatter() {
     let mut data = create_vector::<1, 3>();
-    data[0][0] = "Hello\nWorld".to_string();
-    data[0][1] = "123".to_string();
-    data[0][2] = "asd".to_string();
+    data[0][0] = "Hello\nWorld".into();
+    data[0][1] = "123".into();
+    data[0][2] = "asd".into();
 
     let table = ExpandedDisplay::new(&data)
         .formatter(|s| s.escape_debug().to_string())
@@ -502,12 +496,12 @@ fn display_with_wrap() {
 #[test]
 fn display_with_wrap_colored() {
     let mut data = create_vector::<2, 3>();
-    data[0][2] = "https://getfedora.org/".red().to_string();
+    data[0][2] = "https://getfedora.org/".red().into();
     data[1][1] = "https://endeavouros.com/"
         .white()
         .on_color(AnsiColors::Black)
-        .to_string();
-    data[1][2] = "https://www.opensuse.org/".to_string();
+        .into();
+    data[1][2] = "https://www.opensuse.org/".into();
 
     let table = ExpandedDisplay::new(&data).wrap(2).to_string();
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,4 +1,7 @@
-use std::ops::{Index, IndexMut};
+use std::{
+    borrow::Cow,
+    ops::{Index, IndexMut},
+};
 
 use tabled::Tabled;
 
@@ -30,13 +33,14 @@ impl<const N: usize> IndexMut<usize> for Obj<N> {
 }
 
 impl<const N: usize> Tabled for Obj<N> {
-    fn fields(&self) -> Vec<String> {
-        self.data.clone()
+    fn fields(&self) -> Vec<Cow<'_, str>> {
+        self.data.iter().map(|s| s.into()).collect()
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<Cow<'static, str>> {
         std::iter::once("N".to_owned())
             .chain((0..N).map(|n| format!("column {}", n)))
+            .map(|s| s.into())
             .collect()
     }
 }


### PR DESCRIPTION
Change of `Tabled` trait to

```rust
trait Tabled {
    fn fields(&self) -> Vec<Cow<'_, str>>;
    fn headers() -> Vec<Cow<'static, str>>;
}
```

The idea that we don't waste memory by making copies of `&str`.

Though the interface became less versatile...

I guess there must be done some refactoring then.