### PR TITLE
Update readme about Style usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A list of ready to use styles.
 Styles can be chosen by passing a `Style` argument option.
 
 ```rust
-let table = Table::new(&data).with(Style::PSQL);
+let table = Table::new(&data).with(Style::psql());
 ```
 
 ### Default
@@ -226,7 +226,7 @@ The `Format` function provides an interface for a modification of cells.
 
 ```rust
 Table::new(&data)
-    .with(Style::PSQL),
+    .with(Style::psql()),
     .with(Modify::new(Column(..)).with(Format(|s| format!("<< {} >>", s))))
     .with(Modify::new(Row(..1)).with(Format(|s| format!("Head {}", s))));
 ```
@@ -235,7 +235,7 @@ It's also possible to use functions with signature `Fn(&str) -> String` as a for
 
 ```rust
 Table::new(&data)
-    .with(Style::PSQL),
+    .with(Style::psql()),
     .with(Modify::new(Column(..)).with(|s: &str| format!("<< {} >>", s)))
     .with(Modify::new(Row(..1)).with(str::to_lowercase));
 ```
@@ -337,7 +337,7 @@ The library doesn't bind you in usage of any color library but to be able to wor
 
 ```rust
 Table::new(&data)
-    .with(Style::PSQL)
+    .with(Style::psql())
     .with(Modify::new(Column(..1)).with(Format(|s| s.red().to_string())))
     .with(Modify::new(Column(1..2)).with(Format(|s| s.blue().to_string())))
     .with(Modify::new(Column(2..)).with(Format(|s| s.green().to_string())));
@@ -475,7 +475,7 @@ let data = vec![
     (Developer("Maxim Zhiburt"), Domain::Unknown),
 ];
 
-let table = Table::new(data).with(Style::PSQL).to_string();
+let table = Table::new(data).with(Style::psql()).to_string();
 
 assert_eq!(
     table,


### PR DESCRIPTION
Hello, I'm using tabled in [my pomodoro application](https://github.com/24seconds/rust-cli-pomodoro) and it's really cool!

While applying the Style, I found README about `Style` explanation is not matched to current version (as of [v0.3.0](https://docs.rs/tabled/0.3.0/tabled/style/struct.Style.html#impl)).
So I made update :D.