### PR TITLE
Implement table() trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,20 @@ impl Table {
     }
 }
 
+pub trait TableIteratorExt {
+    fn table(self) -> Table;
+}
+
+impl<T, U> TableIteratorExt for U
+where
+    T: Tabled,
+    U: IntoIterator<Item = T>,
+{
+    fn table(self) -> Table {
+        Table::new(self)
+    }
+}
+
 impl fmt::Display for Table {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.grid)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,13 @@ impl Table {
     }
 }
 
+/// A trait for [IntoIterator] whose Item type is bound to [Tabled].
+/// Any type implements [IntoIterator] can call this function directly
+///
+/// ```text
+/// let people: &[Person] = ...
+/// let table = people.table().with(Style::PSQL);
+/// ```
 pub trait TableIteratorExt {
     fn table(self) -> Table;
 }

--- a/tests/table_test.rs
+++ b/tests/table_test.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use tabled::{Style, Table, Tabled};
+use tabled::{Style, Table, TableIteratorExt, Tabled};
 
 mod default_types {
     use super::*;
@@ -722,6 +722,41 @@ fn tuple_combination() {
     ];
 
     let table = Table::new(data).with(Style::PSQL).to_string();
+
+    assert_eq!(
+        table,
+        concat!(
+            "      name       | Security | Embeded | Frontend | Unknown \n",
+            "-----------------+----------+---------+----------+---------\n",
+            " Terri Kshlerin  |          |    +    |          |         \n",
+            " Catalina Dicki  |    +     |         |          |         \n",
+            " Jennie Schmeler |          |         |    +     |         \n",
+            "  Maxim Zhiburt  |          |         |          |    +    \n"
+        )
+    );
+}
+
+#[test]
+fn table_trait() {
+    #[derive(Tabled)]
+    enum Domain {
+        Security,
+        Embeded,
+        Frontend,
+        Unknown,
+    }
+
+    #[derive(Tabled)]
+    struct Developer(#[header("name")] &'static str);
+
+    let data = vec![
+        (Developer("Terri Kshlerin"), Domain::Embeded),
+        (Developer("Catalina Dicki"), Domain::Security),
+        (Developer("Jennie Schmeler"), Domain::Frontend),
+        (Developer("Maxim Zhiburt"), Domain::Unknown),
+    ];
+
+    let table = (&data).table().with(Style::PSQL).to_string();
 
     assert_eq!(
         table,


### PR DESCRIPTION
I watched the video in Issue #36 and it seems interesting. So I made `TableIteratorExt` trait to support `table()` function. 
(If the comment are needed let me add it. If the trait name is not good let me change it)

```rust
let people: Vec<Person> = ...
let table = people.table()
                  .with(Style::psql());

```
The `TableIteratorExt` applies to the type `U` which is bound to `IntoIterator<Item = T>` type. (T is bound to `Tabled` type)

I don't know which tests to be added, so I simply added one test to `table_test.rs` 
