### PR TITLE
papergrid/ Fix split line styling

### DIFF
--- a/examples/panel.rs
+++ b/examples/panel.rs
@@ -11,33 +11,38 @@ struct Release {
     major_feature: &'static str,
 }
 
-fn main() {
-    let data = [
-        Release {
-            version: "0.2.1",
-            published_date: "2021-06-23",
-            is_active: true,
-            major_feature: "#[header(inline)] attribute",
-        },
-        Release {
-            version: "0.2.0",
-            published_date: "2021-06-19",
-            is_active: false,
-            major_feature: "API changes",
-        },
-        Release {
-            version: "0.1.4",
-            published_date: "2021-06-07",
-            is_active: false,
-            major_feature: "display_with attribute",
-        },
-    ];
+const DATA: [Release; 3] = [
+    Release {
+        version: "0.2.1",
+        published_date: "2021-06-23",
+        is_active: true,
+        major_feature: "#[header(inline)] attribute",
+    },
+    Release {
+        version: "0.2.0",
+        published_date: "2021-06-19",
+        is_active: false,
+        major_feature: "API changes",
+    },
+    Release {
+        version: "0.1.4",
+        published_date: "2021-06-07",
+        is_active: false,
+        major_feature: "display_with attribute",
+    },
+];
 
-    let table = Table::new(&data)
+fn main() {
+    let table = Table::new(DATA)
         .with(Header("Tabled Releases"))
-        .with(Footer(format!("N - {}", data.len())))
-        .with(Style::modern())
-        .with(Modify::new(Full).with(Alignment::Horizontal(AlignmentHorizontal::Center)));
+        .with(Footer(format!("N - {}", DATA.len())))
+        .with(Modify::new(Full).with(Alignment::Horizontal(AlignmentHorizontal::Center)))
+        .with(
+            Style::modern()
+                .top_intersection('─')
+                .bottom_intersection('─')
+                .header_intersection('┬'),
+        );
 
     println!("{}", table);
 }

--- a/papergrid/src/lib.rs
+++ b/papergrid/src/lib.rs
@@ -832,8 +832,6 @@ impl std::fmt::Display for Grid {
             .map(|row| self.get_inner_split_line(row))
             .collect::<Vec<_>>();
 
-        println!("styles={:?}", self.get_split_line(0));
-
         let row_heights = rows_height(&cells, &styles, count_rows, count_columns);
         let widths = columns_width(
             &mut cells,
@@ -843,11 +841,7 @@ impl std::fmt::Display for Grid {
             count_columns,
         );
 
-        println!("widths={:?}", widths);
-
         let normal_widths = normalized_width(&widths, &styles, count_rows, count_columns);
-
-        println!("normal_widths={:?}", normal_widths);
 
         for row in 0..count_rows {
             let inner_border = self.get_inner_split_line(row);
@@ -921,7 +915,6 @@ fn build_row_internals(
     height: usize,
     border: &[BorderLine],
 ) -> fmt::Result {
-    println!("row_styles={} border={}", row_styles.len(), border.len());
     for line_index in 0..height {
         build_line(f, border, row_styles, row.len(), |f, column| {
             build_row_internal_line(

--- a/papergrid/tests/render.rs
+++ b/papergrid/tests/render.rs
@@ -224,9 +224,9 @@ fn render_row_span() {
     grid.set(&Entity::Cell(1, 1), Settings::new().text("1-1"));
 
     let expected = concat!(
-        "+-------+\n",
+        "+---+---+\n",
         "|  0-0  |\n",
-        "+-------+\n",
+        "+---+---+\n",
         "|1-0|1-1|\n",
         "+---+---+\n"
     );
@@ -251,10 +251,10 @@ fn render_miltiline_span() {
     grid.set(&Entity::Cell(1, 1), Settings::new().text("1-1"));
 
     let expected = concat!(
-        "+-------+\n",
+        "+---+---+\n",
         "|  0-0  |\n",
         "|  0-1  |\n",
-        "+-------+\n",
+        "+---+---+\n",
         "|1-0|1-1|\n",
         "+---+---+\n"
     );
@@ -284,15 +284,15 @@ fn render_row_span_multilane() {
     );
 
     let expected = concat!(
-        "+----------+----+\n",
+        "+-----+----+----+\n",
         "|first line|e.g.|\n",
-        "+----------+----+\n",
+        "+-----+----+----+\n",
         "|0    |1   |2   |\n",
         "+-----+----+----+\n",
         "|0    |1   |2   |\n",
         "+-----+----+----+\n",
         "|full last line |\n",
-        "+---------------+\n",
+        "+-----+----+----+\n",
     );
 
     println!("{}", grid);
@@ -317,13 +317,41 @@ fn render_row_span_with_horizontal_ident() {
     let grid = grid.to_string();
 
     let expected = concat!(
-        "+---------------+\n",
+        "+-----------+---+\n",
         "|0-0            |\n",
-        "+---------------+\n",
+        "+-----------+---+\n",
         "|    1-0    |1-1|\n",
         "+-----------+---+\n",
         "|2-0        |2-1|\n",
         "+-----------+---+\n",
+    );
+
+    println!("{}", grid);
+
+    assert_eq!(grid, expected);
+}
+
+#[test]
+fn render_row_span_3x3_with_horizontal_ident() {
+    let mut grid = Grid::new(3, 3);
+    grid.set_cell_borders(DEFAULT_CELL_STYLE.clone());
+
+    grid.set(&Entity::Cell(0, 0), Settings::new().text("0-0").span(3));
+    grid.set(&Entity::Cell(1, 0), Settings::new().text("1-0").span(2));
+    grid.set(&Entity::Cell(2, 0), Settings::new().text("2-0").span(2));
+    grid.set(&Entity::Cell(1, 2), Settings::new().text("1-1"));
+    grid.set(&Entity::Cell(2, 2), Settings::new().text("2-1"));
+
+    let grid = grid.to_string();
+
+    let expected = concat!(
+        "+-+-+---+\n",
+        "|0-0    |\n",
+        "+-+-+---+\n",
+        "|1-0|1-1|\n",
+        "+-+-+---+\n",
+        "|2-0|2-1|\n",
+        "+-+-+---+\n",
     );
 
     println!("{}", grid);
@@ -348,13 +376,13 @@ fn render_row_span_with_different_length() {
     );
 
     let expected = concat!(
-        "+-------------------+\n",
+        "+---------+---------+\n",
         "|first row          |\n",
-        "+-------------------+\n",
+        "+---------+---------+\n",
         "|0        |1        |\n",
         "+---------+---------+\n",
         "|a longer second row|\n",
-        "+-------------------+\n",
+        "+---------+---------+\n",
     );
 
     println!("{}", grid);
@@ -371,7 +399,7 @@ fn render_row_span_with_odd_length() {
     grid.set(&Entity::Cell(1, 0), Settings::new().text("2"));
     grid.set(&Entity::Cell(1, 1), Settings::new().text("4"));
 
-    let expected = concat!("+----+\n", "|3   |\n", "+----+\n", "|2 |4|\n", "+--+-+\n",);
+    let expected = concat!("+--+-+\n", "|3   |\n", "+--+-+\n", "|2 |4|\n", "+--+-+\n",);
 
     assert_eq!(expected, grid.to_string());
 }
@@ -385,13 +413,13 @@ fn render_only_row_spaned() {
     grid.set(&Entity::Cell(1, 0), Settings::new().text("1-0").span(2));
     grid.set(&Entity::Cell(2, 0), Settings::new().text("2-0").span(2));
 
-    let expected = "+---+\n\
+    let expected = "+-+-+\n\
                          |0-0|\n\
-                         +---+\n\
+                         +-+-+\n\
                          |1-0|\n\
-                         +---+\n\
+                         +-+-+\n\
                          |2-0|\n\
-                         +---+\n";
+                         +-+-+\n";
 
     assert_eq!(grid.to_string(), expected);
 }
@@ -426,12 +454,81 @@ fn grid_2x2_span_test() {
     let str = grid.to_string();
     assert_eq!(
         str,
-        "+-------+\n\
+        "+---+---+\n\
          |123    |\n\
-         +-------+\n\
+         +---+---+\n\
          |asd|asd|\n\
          +---+---+\n"
     )
+}
+
+#[test]
+fn grid_2x2_2_span_test() {
+    let mut grid = Grid::new(2, 2);
+    grid.set(&Entity::Global, Settings::new().text("asd"));
+    grid.set_cell_borders(DEFAULT_CELL_STYLE.clone());
+
+    // grid.set(&Entity::Cell(0, 0), Settings::new().text("123").span(2));
+    // grid.set(&Entity::Cell(1, 0), Settings::new().text("asd").span(2));
+
+    // let str = grid.to_string();
+    // assert_eq!(
+    //     str,
+    //     "+-+-+\n\
+    //      |123|\n\
+    //      +-+-+\n\
+    //      |asd|\n\
+    //      +-+-+\n"
+    // );
+
+    grid.set(&Entity::Cell(0, 0), Settings::new().text("1234").span(2));
+    grid.set(&Entity::Cell(1, 0), Settings::new().text("asdw").span(2));
+
+    let str = grid.to_string();
+    assert_eq!(
+        str,
+        "+--+-+\n\
+         |1234|\n\
+         +--+-+\n\
+         |asdw|\n\
+         +--+-+\n"
+    );
+
+    grid.set(&Entity::Cell(0, 0), Settings::new().text("1").span(2));
+    grid.set(&Entity::Cell(1, 0), Settings::new().text("a").span(2));
+
+    let str = grid.to_string();
+    assert_eq!(
+        str,
+        "+++\n\
+         |1|\n\
+         +++\n\
+         |a|\n\
+         +++\n"
+    );
+}
+
+#[test]
+fn render_row_span_with_no_split_style() {
+    let mut grid = Grid::new(2, 2);
+    grid.set_cell_borders(DEFAULT_CELL_STYLE.clone());
+
+    grid.set(
+        &Entity::Cell(0, 0),
+        Settings::new()
+            .text("0-0")
+            .span(2)
+            .alignment(AlignmentHorizontal::Center),
+    );
+    grid.set(&Entity::Cell(0, 1), Settings::new().text(""));
+    grid.set(&Entity::Cell(1, 0), Settings::new().text("1-0"));
+    grid.set(&Entity::Cell(1, 1), Settings::new().text("1-1"));
+
+    grid.clear_split_grid();
+
+    let expected = concat!(" 0-0  \n", "1-01-1\n");
+
+    assert_eq!(expected, grid.to_string());
 }
 
 #[test]

--- a/src/style.rs
+++ b/src/style.rs
@@ -377,15 +377,6 @@ impl TableOption for StyleSettings {
                 );
             }
         }
-
-        // if count_columns > 0 {
-        //     for row in 0..count_rows {
-        //         let cell = grid.style(&Entity::Cell(row, 0));
-        //         if cell.span == count_columns {
-        //             fix_full_span_row(grid, row, count_columns);
-        //         }
-        //     }
-        // }
     }
 }
 
@@ -645,22 +636,6 @@ fn make_style_header(
             border.left_bottom_corner = None;
         }
     }
-}
-
-fn fix_full_span_row(grid: &mut Grid, row: usize, count_columns: usize) {
-    let mut first_cell_border = grid.get_border(row, 0);
-    let last_cell_border = grid.get_border(row, count_columns - 1);
-
-    first_cell_border.right = last_cell_border.right;
-    first_cell_border.right_top_corner = last_cell_border.right_top_corner;
-    first_cell_border.right_bottom_corner = last_cell_border.right_bottom_corner;
-
-    grid.set(
-        &Entity::Cell(row, 0),
-        Settings::default()
-            .border(first_cell_border)
-            .border_restriction(false),
-    );
 }
 
 /// Style is responsible for a look of a [Table].

--- a/src/style.rs
+++ b/src/style.rs
@@ -378,14 +378,14 @@ impl TableOption for StyleSettings {
             }
         }
 
-        if count_columns > 0 {
-            for row in 0..count_rows {
-                let cell = grid.style(&Entity::Cell(row, 0));
-                if cell.span == count_columns {
-                    fix_full_span_row(grid, row, count_columns);
-                }
-            }
-        }
+        // if count_columns > 0 {
+        //     for row in 0..count_rows {
+        //         let cell = grid.style(&Entity::Cell(row, 0));
+        //         if cell.span == count_columns {
+        //             fix_full_span_row(grid, row, count_columns);
+        //         }
+        //     }
+        // }
     }
 }
 

--- a/tests/panel_test.rs
+++ b/tests/panel_test.rs
@@ -15,7 +15,7 @@ fn panel_has_no_style_by_default() {
     // todo: it would be better if vertical split was not set in panel line
     // it is because it has right border printed
     let expected = concat!(
-        "Linux Distributions                  \n",
+        "Linux Distributions                 \n",
         " N | column 0 | column 1 | column 2 \n",
         "---+----------+----------+----------\n",
         " 0 |   0-0    |   0-1    |   0-2    \n",
@@ -23,19 +23,41 @@ fn panel_has_no_style_by_default() {
         " 2 |   2-0    |   2-1    |   2-2    \n",
     );
 
+    println!("{}", table);
+
     assert_eq!(table, expected);
 }
 
 #[test]
 fn highligt_panel() {
+    let border = Border::full('#', '#', '#', '#', '#', '#', '#', '#');
     let table = Table::new(create_vector::<3, 3>())
         .with(Panel("Linux Distributions", 0))
         .with(Style::psql())
-        .with(Highlight::cell(
-            0,
-            0,
-            Border::full('#', '#', '#', '#', '#', '#', '#', '#'),
-        ))
+        .with(Highlight::cell(0, 0, border.clone()))
+        .to_string();
+
+    // todo: it would be better if vertical split was not set in panel line
+    // it is because it has right border printed
+    let expected = concat!(
+        "#####                                \n",
+        "#Linux Distributions                 \n",
+        "#####----------+----------+----------\n",
+        "  N | column 0 | column 1 | column 2 \n",
+        "  0 |   0-0    |   0-1    |   0-2    \n",
+        "  1 |   1-0    |   1-1    |   1-2    \n",
+        "  2 |   2-0    |   2-1    |   2-2    \n",
+    );
+
+    assert_eq!(table, expected);
+
+    let table = Table::new(create_vector::<3, 3>())
+        .with(Panel("Linux Distributions", 0))
+        .with(Style::psql())
+        .with(Highlight::cell(0, 0, border.clone()))
+        .with(Highlight::cell(0, 1, border.clone()))
+        .with(Highlight::cell(0, 2, border.clone()))
+        .with(Highlight::cell(0, 3, border))
         .to_string();
 
     // todo: it would be better if vertical split was not set in panel line
@@ -44,10 +66,10 @@ fn highligt_panel() {
         "######################################\n",
         "#Linux Distributions                 #\n",
         "######################################\n",
-        "  N | column 0 | column 1 | column 2 \n",
-        "  0 |   0-0    |   0-1    |   0-2    \n",
-        "  1 |   1-0    |   1-1    |   1-2    \n",
-        "  2 |   2-0    |   2-1    |   2-2    \n",
+        "  N | column 0 | column 1 | column 2  \n",
+        "  0 |   0-0    |   0-1    |   0-2     \n",
+        "  1 |   1-0    |   1-1    |   1-2     \n",
+        "  2 |   2-0    |   2-1    |   2-2     \n",
     );
 
     assert_eq!(table, expected);
@@ -62,13 +84,15 @@ fn top_panel() {
         .to_string();
 
     let expected = concat!(
-        "        Linux Distributions         |\n",
-        "------------------------------------+\n",
+        "        Linux Distributions         \n",
+        "---+----------+----------+----------\n",
         " N | column 0 | column 1 | column 2 \n",
         " 0 |   0-0    |   0-1    |   0-2    \n",
         " 1 |   1-0    |   1-1    |   1-2    \n",
         " 2 |   2-0    |   2-1    |   2-2    \n",
     );
+
+    println!("{}", table);
 
     assert_eq!(table, expected);
 }
@@ -88,8 +112,10 @@ fn bottom_panel() {
         " 0 |   0-0    |   0-1    |   0-2    \n",
         " 1 |   1-0    |   1-1    |   1-2    \n",
         " 2 |   2-0    |   2-1    |   2-2    \n",
-        "        Linux Distributions         |\n",
+        "        Linux Distributions         \n",
     );
+
+    println!("{}", table);
 
     assert_eq!(table, expected);
 }
@@ -106,7 +132,7 @@ fn inner_panel() {
         " N | column 0 | column 1 | column 2 \n",
         "---+----------+----------+----------\n",
         " 0 |   0-0    |   0-1    |   0-2    \n",
-        "        Linux Distributions         |\n",
+        "        Linux Distributions         \n",
         " 1 |   1-0    |   1-1    |   1-2    \n",
         " 2 |   2-0    |   2-1    |   2-2    \n",
     );
@@ -123,8 +149,8 @@ fn header() {
         .to_string();
 
     let expected = concat!(
-        "        Linux Distributions         |\n",
-        "------------------------------------+\n",
+        "        Linux Distributions         \n",
+        "---+----------+----------+----------\n",
         " N | column 0 | column 1 | column 2 \n",
         " 0 |   0-0    |   0-1    |   0-2    \n",
         " 1 |   1-0    |   1-1    |   1-2    \n",
@@ -145,13 +171,13 @@ fn footer() {
         .to_string();
 
     let expected = concat!(
-        "        Linux Distributions         |\n",
-        "------------------------------------+\n",
+        "        Linux Distributions         \n",
+        "---+----------+----------+----------\n",
         " N | column 0 | column 1 | column 2 \n",
         " 0 |   0-0    |   0-1    |   0-2    \n",
         " 1 |   1-0    |   1-1    |   1-2    \n",
         " 2 |   2-0    |   2-1    |   2-2    \n",
-        "              The end               |\n",
+        "              The end               \n",
     );
 
     assert_eq!(table, expected);
@@ -165,9 +191,9 @@ fn panel_style_uses_most_left_and_right_cell_styles() {
         .to_string();
 
     let expected = concat!(
-        "┌───────────┐\n",
+        "┌─────┬─────┐\n",
         "│Numbers    │\n",
-        "├───────────┤\n",
+        "├─────┼─────┤\n",
         "│ i32 │ i32 │\n",
         "├─────┼─────┤\n",
         "│  0  │  1  │\n",

--- a/tests/panel_test.rs
+++ b/tests/panel_test.rs
@@ -1,6 +1,7 @@
 use crate::util::create_vector;
 use tabled::{
-    Alignment, Border, Footer, Full, Header, Highlight, Modify, Object, Panel, Row, Style, Table,
+    Alignment, Border, Cell, Footer, Full, Header, Highlight, Modify, Object, Panel, Row, Style,
+    Table,
 };
 
 mod util;
@@ -198,6 +199,51 @@ fn panel_style_uses_most_left_and_right_cell_styles() {
         "├─────┼─────┤\n",
         "│  0  │  1  │\n",
         "└─────┴─────┘\n",
+    );
+
+    assert_eq!(table, expected);
+}
+
+#[test]
+fn panel_style_change() {
+    let table = Table::new(&[(0, 1)])
+        .with(tabled::Panel("Numbers", 0))
+        .with(
+            Style::modern()
+                .top_intersection('─')
+                .header_intersection('┬'),
+        )
+        .with(Modify::new(Cell(0, 0)).with(Alignment::center_horizontal()))
+        .to_string();
+
+    let expected = concat!(
+        "┌───────────┐\n",
+        "│  Numbers  │\n",
+        "├─────┬─────┤\n",
+        "│ i32 │ i32 │\n",
+        "├─────┼─────┤\n",
+        "│  0  │  1  │\n",
+        "└─────┴─────┘\n",
+    );
+
+    assert_eq!(table, expected);
+}
+
+#[test]
+fn panel_in_single_column() {
+    let table = Table::new(&[(0)])
+        .with(tabled::Panel("Numbers", 0))
+        .with(Style::modern())
+        .to_string();
+
+    let expected = concat!(
+        "┌───────┐\n",
+        "│Numbers│\n",
+        "├───────┤\n",
+        "│  i32  │\n",
+        "├───────┤\n",
+        "│   0   │\n",
+        "└───────┘\n",
     );
 
     assert_eq!(table, expected);


### PR DESCRIPTION
It changes and approach of rendering split lines for spanned cells.
