### PR TITLE
Fix is_first_word bug

### DIFF
--- a/src/features/width/wrap.rs
+++ b/src/features/width/wrap.rs
@@ -351,7 +351,7 @@ fn split_keeping_words(s: &str, width: usize, sep: &str) -> String {
 
             line.push_str(word);
             line_width += word_width;
-            is_first_word = true;
+            is_first_word = false;
         } else {
             // the word is too long any way so we split it
 


### PR DESCRIPTION
I believe this is correct but this is just a draft MR without tests, so that this (putative) bug isn't forgotten.