### PR TITLE
table: set headers when building from a reference iterator

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -387,7 +387,9 @@ where
             records.push(list);
         }
 
-        Builder::custom(VecRecords::from(records)).build()
+        let mut b = Builder::custom(VecRecords::from(records));
+        b.with_header();
+        b.build()
     }
 }
 


### PR DESCRIPTION
To have the same behaviour as `Table::new()` and avoid having headers mixed with the body of the table.

For example running `./table_to_html/examples/basic.rs` on master produces:

``` html
<table id="tabled-table" border="1">
    <tbody>
        <tr id="tabled-table-0">
            <td id="tabled-table-0-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;" style="text-align: center;">
                <p> name </p>
            </td>
            <td id="tabled-table-0-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;" style="text-align: center;">
                <p> based_on </p>
            </td>
            <td id="tabled-table-0-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;" style="text-align: center;">
                <p> is_active </p>
            </td>
        </tr>
        <tr id="tabled-table-1">
            <td id="tabled-table-1-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Debian </p>
            </td>
            <td id="tabled-table-1-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
            </td>
            <td id="tabled-table-1-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> true </p>
            </td>
        </tr>
        <tr id="tabled-table-2">
            <td id="tabled-table-2-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Arch </p>
            </td>
            <td id="tabled-table-2-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
            </td>
            <td id="tabled-table-2-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> true </p>
            </td>
        </tr>
        <tr id="tabled-table-3">
            <td id="tabled-table-3-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Manjaro </p>
            </td>
            <td id="tabled-table-3-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Arch </p>
            </td>
            <td id="tabled-table-3-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> true </p>
            </td>
        </tr>
    </tbody>
</table>
```

with this fix it wraps the headers into `<thead></thead>` tag, eg:

``` html
<table id="tabled-table" border="1">
    <thead>
        <tr id="tabled-table-0">
            <th id="tabled-table-0-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;" style="text-align: center;">
                <p> name </p>
            </th>
            <th id="tabled-table-0-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;" style="text-align: center;">
                <p> based_on </p>
            </th>
            <th id="tabled-table-0-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;" style="text-align: center;">
                <p> is_active </p>
            </th>
        </tr>
    </thead>
    <tbody>
        <tr id="tabled-table-1">
            <td id="tabled-table-1-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Debian </p>
            </td>
            <td id="tabled-table-1-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
            </td>
            <td id="tabled-table-1-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> true </p>
            </td>
        </tr>
        <tr id="tabled-table-2">
            <td id="tabled-table-2-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Arch </p>
            </td>
            <td id="tabled-table-2-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
            </td>
            <td id="tabled-table-2-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> true </p>
            </td>
        </tr>
        <tr id="tabled-table-3">
            <td id="tabled-table-3-0" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Manjaro </p>
            </td>
            <td id="tabled-table-3-1" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> Arch </p>
            </td>
            <td id="tabled-table-3-2" style="padding-top: 0rem; padding-bottom: 0rem; padding-left: 1rem; padding-right: 1rem;">
                <p> true </p>
            </td>
        </tr>
    </tbody>
</table>
```