### PR TITLE
fix json_to_table test

### DIFF
--- a/json_to_table/tests/test_config.rs
+++ b/json_to_table/tests/test_config.rs
@@ -119,10 +119,7 @@ fn color_test() {
     );
 
     let mut cfg = GridConfig::default();
-    cfg.set_border_color_global(AnsiColor::new(
-        String::from("\u{1b}[34m"),
-        String::from("\u{1b}[39m"),
-    ));
+    cfg.set_border_color_global(AnsiColor::new("\u{1b}[34m".into(), "\u{1b}[39m".into()));
 
     let table = json_to_table(&value)
         .set_style(Style::modern())


### PR DESCRIPTION
this test has the wrong type in the constructor

i guess the CI is not covering this feature?
looks like the `check` target is not checking `--all-targets` or the whole workspace (`--all`)