### PR TITLE
deprecates most usages of 'actions-rs'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,47 +21,30 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust || 'stable' }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features=${{ matrix.features }}
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --no-default-features --features=${{ matrix.features }}
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all -- -D warnings
+      - run: cargo clippy --all -- -D warnings
 
   test:
     name: Unit Test Suite
@@ -73,16 +56,10 @@ jobs:
         features: ["", "color"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           target: ${{ matrix.target }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --no-fail-fast --target ${{ matrix.target }} --features=${{ matrix.features }}
+      - run: cargo test --workspace --no-fail-fast --target ${{ matrix.target }} --features=${{ matrix.features }}
 
   test_quickcheck:
     name: A quickcheck test suite
@@ -90,15 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --no-fail-fast -- --include-ignored qc_
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --workspace --no-fail-fast -- --include-ignored qc_
 
   coverage:
     name: Coveralls
@@ -106,11 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:


### PR DESCRIPTION
'actions-rs' is unmaintained. This PR removes *most* of the usages from CI