### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
enables dependabot for both rust and github action dependencies.

This should not be merged until after #264, otherwise dependency updates may result in unintended MSRV bumps that won't be caught by CI