### PR TITLE
Fixed spelling mistakes in documentation

### DIFF
--- a/csv_to_table/src/records.rs
+++ b/csv_to_table/src/records.rs
@@ -5,16 +5,16 @@ use tabled::records::IntoRecords;
 
 /// A [`IntoRecords`] implementation for a [`csv::Reader`].
 ///
-/// By default all errors are ignored, but you can print them using [`CsvRecords::print_erorrs`].
+/// By default all errors are ignored, but you can print them using [`CsvRecords::print_errors`].
 ///
-/// [`CsvRecords::print_erorrs`]: CsvRecords.print_errors
+/// [`CsvRecords::print_errors`]: CsvRecords.print_errors
 pub struct CsvRecords<R> {
     rows: StringRecordsIntoIter<R>,
-    err_logic: ErorrLogic,
+    err_logic: ErrorLogic,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum ErorrLogic {
+enum ErrorLogic {
     Ignore,
     Print,
 }
@@ -27,13 +27,13 @@ impl<R> CsvRecords<R> {
     {
         Self {
             rows: reader.into_records(),
-            err_logic: ErorrLogic::Ignore,
+            err_logic: ErrorLogic::Ignore,
         }
     }
 
     /// Show underlying [Read] errors inside a table.
     pub fn print_errors(mut self) -> Self {
-        self.err_logic = ErorrLogic::Print;
+        self.err_logic = ErrorLogic::Print;
         self
     }
 }
@@ -41,7 +41,7 @@ impl<R> CsvRecords<R> {
 /// A row iterator.
 pub struct CsvStringRecordsRows<R> {
     iter: StringRecordsIntoIter<R>,
-    err_logic: ErorrLogic,
+    err_logic: ErrorLogic,
 }
 
 impl<R> Iterator for CsvStringRecordsRows<R>
@@ -57,8 +57,8 @@ where
             match result {
                 Ok(record) => return Some(CsvStringRecord::new(record)),
                 Err(err) => match self.err_logic {
-                    ErorrLogic::Ignore => continue,
-                    ErorrLogic::Print => {
+                    ErrorLogic::Ignore => continue,
+                    ErrorLogic::Print => {
                         let err = err.to_string();
                         let mut record = StringRecord::with_capacity(err.len(), 1);
                         record.push_field(&err);

--- a/papergrid/src/config/border.rs
+++ b/papergrid/src/config/border.rs
@@ -75,7 +75,7 @@ impl<T> Border<T> {
 impl<T: Copy> Border<T> {
     /// This function constructs a cell borders with all sides's char set to a given character.
     ///
-    /// It behaives like [`Border::full`] with the same character set to each side.
+    /// It behaves like [`Border::full`] with the same character set to each side.
     pub fn filled(c: T) -> Self {
         Self::full(c, c, c, c, c, c, c, c)
     }
@@ -84,7 +84,7 @@ impl<T: Copy> Border<T> {
 impl<T: Copy> Border<&T> {
     /// This function constructs a cell borders with all sides's char set to a given character.
     ///
-    /// It behaives like [`Border::full`] with the same character set to each side.
+    /// It behaves like [`Border::full`] with the same character set to each side.
     pub fn copied(&self) -> Border<T> {
         Border {
             top: self.top.copied(),
@@ -102,7 +102,7 @@ impl<T: Copy> Border<&T> {
 impl<T: Clone> Border<&T> {
     /// This function constructs a cell borders with all sides's char set to a given character.
     ///
-    /// It behaives like [`Border::full`] with the same character set to each side.
+    /// It behaves like [`Border::full`] with the same character set to each side.
     pub fn cloned(&self) -> Border<T> {
         Border {
             top: self.top.cloned(),

--- a/papergrid/src/config/indent.rs
+++ b/papergrid/src/config/indent.rs
@@ -13,12 +13,12 @@ impl Indent {
         Self { fill, size }
     }
 
-    /// Creates a new Indent startucture with space (`' '`) as a fill character.
+    /// Creates a new Indent structure with space (`' '`) as a fill character.
     pub const fn spaced(size: usize) -> Self {
         Self { size, fill: ' ' }
     }
 
-    /// Creates a new Indent startucture with space (`' '`) as a fill character.
+    /// Creates a new Indent structure with space (`' '`) as a fill character.
     pub const fn zero() -> Self {
         Self::new(0, ' ')
     }

--- a/papergrid/src/grid/compact/config.rs
+++ b/papergrid/src/grid/compact/config.rs
@@ -29,7 +29,7 @@ impl Default for CompactConfig {
 }
 
 impl CompactConfig {
-    /// Returns an standart config.
+    /// Returns an standard config.
     pub const fn empty() -> Self {
         Self {
             tab_width: 4,
@@ -55,7 +55,7 @@ impl CompactConfig {
         &self.margin
     }
 
-    /// Set the [`Borders`] value as currect one.
+    /// Set the [`Borders`] value as correct one.
     pub const fn set_borders(mut self, borders: Borders<char>) -> Self {
         self.borders = borders;
         self

--- a/papergrid/src/grid/compact/grid.rs
+++ b/papergrid/src/grid/compact/grid.rs
@@ -80,7 +80,7 @@ impl<R, D, G, C> CompactGrid<R, D, G, C> {
         C: Colors,
     {
         let mut buf = String::new();
-        self.build(&mut buf).expect("It's guaranted to never happen otherwise it's considered an stdlib erorr or impl error");
+        self.build(&mut buf).expect("It's guaranteed to never happen otherwise it's considered an stdlib error or impl error");
         buf
     }
 }
@@ -594,7 +594,7 @@ fn print_text<F: Write>(f: &mut F, s: &str, tab: usize, clr: Option<impl Color>)
 
 fn print_str<F: Write>(f: &mut F, text: &str, tab_width: usize) -> fmt::Result {
     // So to not use replace_tab we are printing by char;
-    // Hopefully it's more affective as it reduceses a number of allocations.
+    // Hopefully it's more effective as it reduces a number of allocations.
     for c in text.chars() {
         match c {
             '\r' => (),

--- a/papergrid/src/grid/mod.rs
+++ b/papergrid/src/grid/mod.rs
@@ -1,4 +1,4 @@
-//! Module contains a list of backends for pritty print tables.
+//! Module contains a list of backends for pretty print tables.
 
 pub mod compact;
 

--- a/papergrid/src/grid/spanned/config/entity_map.rs
+++ b/papergrid/src/grid/spanned/config/entity_map.rs
@@ -36,7 +36,7 @@ impl<T> EntityMap<T> {
             Entity::Cell(row, col) => {
                 // todo: optimize;
                 //
-                // Cause we can change rows/columns/cells separetely we need to check them separately.
+                // Cause we can change rows/columns/cells separately we need to check them separately.
                 // But we often doing this checks in `Grid::fmt` and I believe if we could optimize it it could be beneficial.
                 //
                 // Haven't found a solution for that yet.

--- a/papergrid/src/grid/spanned/config/mod.rs
+++ b/papergrid/src/grid/spanned/config/mod.rs
@@ -165,7 +165,7 @@ impl GridConfig {
         self.override_vertical_borders.clear();
     }
 
-    /// Set the [`Borders`] value as currect one.
+    /// Set the [`Borders`] value as correct one.
     pub fn set_borders(&mut self, borders: Borders) {
         self.borders.set_borders(borders);
     }

--- a/papergrid/src/grid/spanned/dimension.rs
+++ b/papergrid/src/grid/spanned/dimension.rs
@@ -118,16 +118,13 @@ fn adjust_hspans(
         return;
     }
 
-    // The overall height disctribution will be different depend on the order.
+    // The overall height distribution will be different depend on the order.
     //
     // We sort spans in order to prioritize the smaller spans first.
     //
     // todo: we actually have a span list already.... so we could keep order from the begining
-    let mut spans_ordered = spans
-        .iter()
-        .map(|(k, v)| ((k.0, k.1), *v))
-        .collect::<Vec<_>>();
-    spans_ordered.sort_unstable_by(|(arow, acol), (brow, bcol)| match arow.cmp(brow) {
+    let mut spans_orderd = cfg.iter_span_rows().collect::<Vec<_>>();
+    spans_orderd.sort_unstable_by(|(arow, acol), (brow, bcol)| match arow.cmp(brow) {
         Ordering::Equal => acol.cmp(bcol),
         ord => ord,
     });
@@ -209,7 +206,7 @@ fn adjust_vspans(
         return;
     }
 
-    // The overall width disctribution will be different depend on the order.
+    // The overall width distribution will be different depend on the order.
     //
     // We sort spans in order to prioritize the smaller spans first.
     let mut spans_ordered = spans

--- a/papergrid/src/grid/spanned/dimension.rs
+++ b/papergrid/src/grid/spanned/dimension.rs
@@ -119,12 +119,14 @@ fn adjust_hspans(
     }
 
     // The overall height distribution will be different depend on the order.
-    //
     // We sort spans in order to prioritize the smaller spans first.
     //
     // todo: we actually have a span list already.... so we could keep order from the begining
-    let mut spans_orderd = cfg.iter_span_rows().collect::<Vec<_>>();
-    spans_orderd.sort_unstable_by(|(arow, acol), (brow, bcol)| match arow.cmp(brow) {
+    let mut spans_ordered = spans
+        .iter()
+        .map(|(k, v)| ((k.0, k.1), *v))
+        .collect::<Vec<_>>();
+    spans_ordered.sort_unstable_by(|(arow, acol), (brow, bcol)| match arow.cmp(brow) {
         Ordering::Equal => acol.cmp(bcol),
         ord => ord,
     });

--- a/papergrid/src/grid/spanned/grid.rs
+++ b/papergrid/src/grid/spanned/grid.rs
@@ -258,8 +258,6 @@ where
     collect_columns(&mut buf, columns, cfg, colors, dimension, height, row);
     print_columns_lines(f, &mut buf, height, cfg, line, row, totalh, shape)?;
 
-    buf.clear();
-
     Ok(())
 }
 

--- a/papergrid/src/grid/spanned/grid.rs
+++ b/papergrid/src/grid/spanned/grid.rs
@@ -84,7 +84,7 @@ impl<R, D, G, C> Grid<R, D, G, C> {
         C: Colors,
     {
         let mut buf = String::new();
-        self.build(&mut buf).expect("It's guaranted to never happen otherwise it's considered an stdlib erorr or impl error");
+        self.build(&mut buf).expect("It's guaranteed to never happen otherwise it's considered an stdlib error or impl error");
         buf
     }
 }
@@ -431,7 +431,7 @@ fn print_split_line<F: Write, D: Dimension>(
             let left = cfg.get_intersection((row, col), shape);
             if let Some(c) = left {
                 if i >= override_text_pos && !override_text.is_empty() {
-                    let (c, rest) = spplit_str_at(&override_text, 1);
+                    let (c, rest) = split_str_at(&override_text, 1);
                     f.write_str(&c)?;
                     override_text = rest.into_owned();
                     if string_width(&override_text) == 0 {
@@ -474,7 +474,7 @@ fn print_split_line<F: Write, D: Dimension>(
         if i >= override_text_pos && !override_text.is_empty() {
             let text_width = string_width_tab(&override_text, cfg.get_tab_width());
             let print_width = cmp::min(text_width, width);
-            let (c, rest) = spplit_str_at(&override_text, print_width);
+            let (c, rest) = split_str_at(&override_text, print_width);
             f.write_str(&c)?;
             override_text = rest.into_owned();
             if string_width(&override_text) == 0 {
@@ -503,7 +503,7 @@ fn print_split_line<F: Write, D: Dimension>(
         let right = cfg.get_intersection((row, col + 1), shape);
         if let Some(c) = right {
             if i >= override_text_pos && !override_text.is_empty() {
-                let (c, rest) = spplit_str_at(&override_text, 1);
+                let (c, rest) = split_str_at(&override_text, 1);
                 f.write_str(&c)?;
                 override_text = rest.into_owned();
                 if string_width(&override_text) == 0 {
@@ -636,7 +636,7 @@ fn print_split_line_spanned<S, F: Write, D: Dimension, C: Color>(
             let left = cfg.get_intersection((row, col), shape);
             if let Some(c) = left {
                 if i >= override_text_pos && !override_text.is_empty() {
-                    let (c, rest) = spplit_str_at(&override_text, 1);
+                    let (c, rest) = split_str_at(&override_text, 1);
                     f.write_str(&c)?;
                     override_text = rest.into_owned();
                     if string_width(&override_text) == 0 {
@@ -700,7 +700,7 @@ fn print_split_line_spanned<S, F: Write, D: Dimension, C: Color>(
                 let text_width = string_width_tab(&override_text, cfg.get_tab_width());
                 let print_width = cmp::min(text_width, width);
 
-                let (c, rest) = spplit_str_at(&override_text, print_width);
+                let (c, rest) = split_str_at(&override_text, print_width);
                 f.write_str(&c)?;
 
                 override_text = rest.into_owned();
@@ -729,7 +729,7 @@ fn print_split_line_spanned<S, F: Write, D: Dimension, C: Color>(
         let right = cfg.get_intersection((row, col + 1), shape);
         if let Some(c) = right {
             if i >= override_text_pos && !override_text.is_empty() {
-                let (c, rest) = spplit_str_at(&override_text, 1);
+                let (c, rest) = split_str_at(&override_text, 1);
                 f.write_str(&c)?;
                 override_text = rest.into_owned();
                 if string_width(&override_text) == 0 {
@@ -774,7 +774,7 @@ where
     C: Colors,
 {
     if this_height == 0 {
-        // it's possible that we dont show row but it contains an actuall cell which will be
+        // it's possible that we dont show row but it contains an actual cell which will be
         // rendered after all cause it's a rowspanned
 
         let mut skip = 0;
@@ -1049,7 +1049,7 @@ impl<C> LinesIter<C> {
         C: AsRef<str>,
     {
         // We want to not allocate a String/Vec.
-        // It's currerently not possible due to a lifetime issues. (It's known as self-referential struct)
+        // It's currently not possible due to a lifetime issues. (It's known as self-referential struct)
         //
         // Here we change the lifetime of text.
         //
@@ -1121,7 +1121,7 @@ fn print_text<F: Write>(f: &mut F, s: &str, tab: usize, clr: Option<impl Color>)
 
 fn print_str<F: Write>(f: &mut F, text: &str, tab_width: usize) -> fmt::Result {
     // So to not use replace_tab we are printing by char;
-    // Hopefully it's more affective as it reduceses a number of allocations.
+    // Hopefully it's more effective as it reduces a number of allocations.
     for c in text.chars() {
         match c {
             '\r' => (),
@@ -1497,7 +1497,7 @@ fn convert_count_rows(row: usize, is_last: bool) -> usize {
 /// Get string at
 ///
 /// BE AWARE: width is expected to be in bytes.
-fn spplit_str_at(text: &str, at: usize) -> (Cow<'_, str>, Cow<'_, str>) {
+fn split_str_at(text: &str, at: usize) -> (Cow<'_, str>, Cow<'_, str>) {
     #[cfg(feature = "color")]
     {
         const REPLACEMENT: char = '\u{FFFD}';
@@ -1537,7 +1537,7 @@ fn spplit_str_at(text: &str, at: usize) -> (Cow<'_, str>, Cow<'_, str>) {
 
 /// The function splits a string in the position and
 /// returns a exact number of bytes before the position and in case of a split in an unicode grapheme
-/// a width of a character which was tried to be splited in.
+/// a width of a character which was tried to be splitted in.
 ///
 /// BE AWARE: pos is expected to be in bytes.
 fn split_at_pos(s: &str, pos: usize) -> (usize, usize, usize) {

--- a/papergrid/src/grid/spanned/mod.rs
+++ b/papergrid/src/grid/spanned/mod.rs
@@ -1,4 +1,4 @@
-//! The module provides a grid backend [`Grid`] for pritty print tables.
+//! The module provides a grid backend [`Grid`] for pretty print tables.
 //!
 //! If you know your data at compile time and you do no need a reach set of configuration,
 //! you might better use [`CompactGrid`] cause it is considered more performant.

--- a/papergrid/src/util/string.rs
+++ b/papergrid/src/util/string.rs
@@ -119,8 +119,7 @@ pub fn get_lines(text: &str) -> Lines<'_> {
     #[cfg(not(feature = "color"))]
     {
         // we call `split()` but not `lines()` in order to match colored implementation
-        // specifically how we treat a traling '\n' character.
-
+        // specifically how we treat a trailing '\n' character.
         Lines {
             inner: text.split('\n'),
         }

--- a/static_table/src/lib.rs
+++ b/static_table/src/lib.rs
@@ -194,7 +194,7 @@ use tabled::{
 /// Supported settings are:
 ///
 /// - THEME
-/// - ALIGNMNET
+/// - ALIGNMENT
 /// - PADDING
 /// - MARGIN
 #[proc_macro]
@@ -794,7 +794,7 @@ fn panic_not_supported_theme(ident: &LitStr) {
         ident,
         "The given settings is not supported";
         note="custom themes are yet not supported";
-        help = r#"Supported theames are [EMPTY, BLANK, ASCII, ASCII_ROUNDED, DOTS, MODERN, SHARP, ROUNDED, EXTENDED, RE_STRUCTURED_TEXT, MARKDOWN, PSQL]"#
+        help = r#"Supported themes are [EMPTY, BLANK, ASCII, ASCII_ROUNDED, DOTS, MODERN, SHARP, ROUNDED, EXTENDED, RE_STRUCTURED_TEXT, MARKDOWN, PSQL]"#
     )
 }
 

--- a/table_to_html/tests/table.rs
+++ b/table_to_html/tests/table.rs
@@ -1146,7 +1146,7 @@ fn table_margin() {
 }
 
 #[test]
-fn table_bordr() {
+fn table_border() {
     let builder = Table::builder([["123", "324", "zxc"], ["123", "324", "zxc"]]);
     let mut table = HtmlTable::from(builder);
     table.set_border(10);

--- a/tabled/examples/rotate.rs
+++ b/tabled/examples/rotate.rs
@@ -6,15 +6,15 @@ use tabled::{settings::rotate::Rotate, Table, Tabled};
 #[derive(Tabled)]
 struct Linux {
     id: u8,
-    destribution: &'static str,
+    distribution: &'static str,
     link: &'static str,
 }
 
 impl Linux {
-    fn new(id: u8, destribution: &'static str, link: &'static str) -> Self {
+    fn new(id: u8, distribution: &'static str, link: &'static str) -> Self {
         Self {
             id,
-            destribution,
+            distribution,
             link,
         }
     }

--- a/tabled/examples/shadow.rs
+++ b/tabled/examples/shadow.rs
@@ -1,4 +1,4 @@
-//! The example relayes on STDIN to read the message which will be outputted.
+//! The example relays on STDIN to read the message which will be outputted.
 //!
 //! The table is inspired by <https://en.wikipedia.org/wiki/Box-drawing_character>
 //!

--- a/tabled/src/builder/table_builder.rs
+++ b/tabled/src/builder/table_builder.rs
@@ -1,6 +1,6 @@
 // todo: I'd rather switch back to -> Self from -> &mut Self
 //
-// but these &self methods are definetely a smell...
+// but these &self methods are definitely a smell...
 
 use std::{borrow::Cow, iter::FromIterator};
 

--- a/tabled/src/lib.rs
+++ b/tabled/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The library supports different approaches of table building.
 //! You can use [`Tabled`] trait if the data type is known.
-//! Or you can use [`Builder`] to construct the table from stractch.
+//! Or you can use [`Builder`] to construct the table from scratch.
 //!
 //! ## Usage
 //!
@@ -352,7 +352,7 @@ pub use crate::{tabled::Tabled, tables::table::Table};
 ///
 /// ### Hide a column
 ///
-/// You can mark filds as hidden in which case they fill be ignored and not be present on a sheet.
+/// You can mark fields as hidden in which case they fill be ignored and not be present on a sheet.
 ///
 /// A similar affect could be achieved by the means of a `Disable` setting.
 ///

--- a/tabled/src/records/into_records/buf_records.rs
+++ b/tabled/src/records/into_records/buf_records.rs
@@ -1,6 +1,6 @@
 //! A module contains [`BufRows`] and [`BufColumns`] iterators.
 //!
-//! Almoust always they both can be used interchangably but [`BufRows`] is supposed to be lighter cause it
+//! Almoust always they both can be used interchangeably but [`BufRows`] is supposed to be lighter cause it
 //! does not reads columns.
 
 use crate::records::IntoRecords;

--- a/tabled/src/records/mod.rs
+++ b/tabled/src/records/mod.rs
@@ -23,14 +23,14 @@ pub use empty_records::EmptyRecords;
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use vec_records::VecRecords;
 
-/// [Records] extension which guarantess the amount of rows.
+/// [Records] extension which guarantees the amount of rows.
 pub trait ExactRecords {
     /// A cell represented by a string value.
     type Cell: AsRef<str>;
 
     /// Returns an exact amount of rows in records.
     ///
-    /// It must be guarated that an iterator will yield this amount.
+    /// It must be guaranteed that an iterator will yield this amount.
     fn count_rows(&self) -> usize;
 
     /// Returns a text of a cell by an index.

--- a/tabled/src/settings/concat/mod.rs
+++ b/tabled/src/settings/concat/mod.rs
@@ -57,13 +57,13 @@ use crate::{
     Table,
 };
 
-/// [`Concat`] concatenate tables along a particular axis [Horizontal | Vertical].
+/// [`Concat`] concatenates tables along a particular axis [Horizontal | Vertical].
 /// It doesn't do any key or column comparisons like SQL's join does.
 ///
 /// When the tables has different sizes, empty cells will be created by default.
 ///
-/// [`Concat`] in horizontal mode has similar behaiviour to tuples `(a, b)`.
-/// But it behaives on tables rather than on an actual data.
+/// [`Concat`] in horizontal mode has similar behaviour to tuples `(a, b)`.
+/// But it behaves on tables rather than on an actual data.
 ///
 /// ```
 /// use tabled::{Table, settings::concat::Concat};

--- a/tabled/src/settings/extract/mod.rs
+++ b/tabled/src/settings/extract/mod.rs
@@ -164,7 +164,7 @@ where
             count_columns,
         );
 
-        // Cleanup table in case if boundaries are exeeded.
+        // Cleanup table in case if boundaries are exceeded.
         //
         // todo: can be optimized by adding a clear() method to Resizable
         rows.0 = std::cmp::min(rows.0, count_rows);

--- a/tabled/src/settings/format/format_positioned.rs
+++ b/tabled/src/settings/format/format_positioned.rs
@@ -6,7 +6,7 @@ use crate::{
 
 /// [`FormatContentPositioned`] is like a [`FormatContent`] an abstraction over a function you can use against a cell.
 ///
-/// It differerent from [`FormatContent`] that it provides a row and column index.
+/// It different from [`FormatContent`] that it provides a row and column index.
 ///
 /// [`FormatContent`]: crate::settings::format::FormatContent
 #[derive(Debug)]

--- a/tabled/src/settings/object/segment.rs
+++ b/tabled/src/settings/object/segment.rs
@@ -58,9 +58,9 @@ where
     }
 }
 
-/// This is a segment which cantains all cells on the table.
+/// This is a segment which contains all cells on the table.
 ///
-/// Can be crated from [`Segment::all`].
+/// Can be created from [`Segment::all`].
 #[derive(Debug)]
 pub struct SegmentAll;
 

--- a/tabled/src/settings/panel/mod.rs
+++ b/tabled/src/settings/panel/mod.rs
@@ -1,4 +1,4 @@
-//! This module contains primitivies to create a spread row.
+//! This module contains primitives to create a spread row.
 //! Ultimately it is a cell with a span set to a number of columns on the [`Table`].
 //!
 //! You can use a [`Span`] to set a custom span.

--- a/tabled/src/settings/rotate/mod.rs
+++ b/tabled/src/settings/rotate/mod.rs
@@ -47,13 +47,13 @@ pub enum Rotate {
     Right,
     /// Rotate [`Table`] to the top.
     ///
-    /// So the top becames the bottom.
+    /// So the top becomes the bottom.
     ///
     /// [`Table`]: crate::Table
     Top,
     /// Rotate [`Table`] to the bottom.
     ///
-    /// So the top becames the bottom.
+    /// So the top becomes the bottom.
     ///
     /// [`Table`]: crate::Table
     Bottom,

--- a/tabled/src/settings/style/border.rs
+++ b/tabled/src/settings/style/border.rs
@@ -57,7 +57,7 @@ impl Border {
     }
 
     /// This function constructs a cell borders with all sides's char set to a given character.
-    /// It behaives like [`Border::full`] with the same character set to each side.
+    /// It behaves like [`Border::full`] with the same character set to each side.
     pub const fn filled(c: char) -> Self {
         Self::full(c, c, c, c, c, c, c, c)
     }

--- a/tabled/src/settings/style/border_color.rs
+++ b/tabled/src/settings/style/border_color.rs
@@ -51,7 +51,7 @@ impl BorderColor {
     }
 
     /// This function constructs a cell borders with all sides's char set to a given character.
-    /// It behaives like [`Border::full`] with the same character set to each side.
+    /// It behaves like [`Border::full`] with the same character set to each side.
     pub fn filled(c: Color) -> Self {
         let c: AnsiColor<'_> = c.into();
 

--- a/tabled/src/settings/style/mod.rs
+++ b/tabled/src/settings/style/mod.rs
@@ -85,7 +85,7 @@
 //!
 //! ## [`RawStyle`]
 //!
-//! A different representatio of [`Style`].
+//! A different representation of [`Style`].
 //! With no checks in place.
 //!
 //! It also contains a list of types to support colors.

--- a/tabled/src/settings/style/raw_style.rs
+++ b/tabled/src/settings/style/raw_style.rs
@@ -71,13 +71,13 @@ impl RawStyle {
         self
     }
 
-    /// Set a top interesion character.
+    /// Set a top intersection character.
     pub fn set_intersection_top(&mut self, s: Option<char>) -> &mut Self {
         self.borders.top_intersection = s;
         self
     }
 
-    /// Set a top interesion color.
+    /// Set a top intersection color.
     pub fn set_color_intersection_top(&mut self, color: Color) -> &mut Self {
         self.colors.top_intersection = Some(color.into());
         self
@@ -89,7 +89,7 @@ impl RawStyle {
         self
     }
 
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_intersection_bottom(&mut self, color: Color) -> &mut Self {
         self.colors.bottom_intersection = Some(color.into());
         self
@@ -101,7 +101,7 @@ impl RawStyle {
         self
     }
 
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_intersection_left(&mut self, color: Color) -> &mut Self {
         self.colors.left_intersection = Some(color.into());
         self
@@ -113,7 +113,7 @@ impl RawStyle {
         self
     }
 
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_intersection_right(&mut self, color: Color) -> &mut Self {
         self.colors.right_intersection = Some(color.into());
         self
@@ -125,7 +125,7 @@ impl RawStyle {
         self
     }
 
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_intersection(&mut self, color: Color) -> &mut Self {
         self.colors.intersection = Some(color.into());
         self
@@ -137,7 +137,7 @@ impl RawStyle {
         self
     }
 
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_vertical(&mut self, color: Color) -> &mut Self {
         self.colors.vertical = Some(color.into());
         self
@@ -149,7 +149,7 @@ impl RawStyle {
         self
     }
 
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_horizontal(&mut self, color: Color) -> &mut Self {
         self.colors.horizontal = Some(color.into());
         self
@@ -160,7 +160,7 @@ impl RawStyle {
         self.borders.top_left = s;
         self
     }
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_corner_top_left(&mut self, color: Color) -> &mut Self {
         self.colors.top_left = Some(color.into());
         self
@@ -172,7 +172,7 @@ impl RawStyle {
         self
     }
 
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_corner_top_right(&mut self, color: Color) -> &mut Self {
         self.colors.top_right = Some(color.into());
         self
@@ -183,7 +183,7 @@ impl RawStyle {
         self.borders.bottom_left = s;
         self
     }
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_corner_bottom_left(&mut self, color: Color) -> &mut Self {
         self.colors.bottom_left = Some(color.into());
         self
@@ -194,7 +194,7 @@ impl RawStyle {
         self.borders.bottom_right = s;
         self
     }
-    /// Set a bottom interesion color.
+    /// Set a bottom intersection color.
     pub fn set_color_corner_bottom_right(&mut self, color: Color) -> &mut Self {
         self.colors.bottom_right = Some(color.into());
         self

--- a/tabled/src/settings/style/span_border_correction.rs
+++ b/tabled/src/settings/style/span_border_correction.rs
@@ -1,5 +1,5 @@
-//! This module contains [`BorderSpanCorrection`] structure, which can be usefull when [`Span`] is used, and
-//! you wan't to fix the intersections symbols which are left intact by default.
+//! This module contains [`BorderSpanCorrection`] structure, which can be useful when [`Span`] is used, and
+//! you want to fix the intersections symbols which are left intact by default.
 //!
 //! [`Span`]: crate::settings::span::Span
 

--- a/tabled/src/settings/table_option.rs
+++ b/tabled/src/settings/table_option.rs
@@ -1,4 +1,4 @@
-/// A trait which is responsilbe for configuration of a [`Table`].
+/// A trait which is responsible for configuration of a [`Table`].
 ///
 /// [`Table`]: crate::Table
 pub trait TableOption<R, D, C> {
@@ -15,7 +15,7 @@ where
     }
 }
 
-// todo: we can create 2 dimmerent TableOptions
-// 1 will do actuall calculation and will do NOCache while other will do cache
+// todo: we can create 2 different TableOptions
+// 1 will do actual calculation and will do NOCache while other will do cache
 //
 // So Width::wrap will be something Wrap(Vec::new()) and will have some methods right in it.

--- a/tabled/src/settings/width/truncate.rs
+++ b/tabled/src/settings/width/truncate.rs
@@ -92,7 +92,7 @@ where
 impl<'a, W, P> Truncate<'a, W, P> {
     /// Sets a suffix which will be appended to a resultant string.
     ///
-    /// The suffix is used in 3 circamstances:
+    /// The suffix is used in 3 circumstances:
     ///     1. If original string is *bigger* than the suffix.
     ///        We cut more of the original string and append the suffix.
     ///     2. If suffix is bigger than the original string.

--- a/tabled/src/tables/compact/mod.rs
+++ b/tabled/src/tables/compact/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains a [`CompactTable`] table.
 //!
 //! In contrast to [`Table`] [`CompactTable`] does no allocations but it consumes an iterator.
-//! It's usefull when you dont want to re/allocate a buffer for your data.
+//! It's useful when you don't want to re/allocate a buffer for your data.
 //!
 //! # Example
 //!

--- a/tabled/src/tables/iter/mod.rs
+++ b/tabled/src/tables/iter/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains a [`IterTable`] table.
 //!
 //! In contrast to [`Table`] [`IterTable`] does no allocations but it consumes an iterator.
-//! It's usefull when you dont want to re/allocate a buffer for your data.
+//! It's useful when you don't want to re/allocate a buffer for your data.
 //!
 //! # Example
 //!

--- a/tabled/src/tables/mod.rs
+++ b/tabled/src/tables/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! ## [`extended`]
 //!
-//! Has a table which is usefull for large amount of data.
+//! Has a table which is useful for large amount of data.
 
 pub mod compact;
 

--- a/tabled/src/tables/table/dimension.rs
+++ b/tabled/src/tables/table/dimension.rs
@@ -23,7 +23,7 @@ impl TableDimension<'_> {
 
     /// Set column widths.
     ///
-    /// In general the method is only considered to be usefull to a [`TableOption`].
+    /// In general the method is only considered to be useful to a [`TableOption`].
     ///
     /// BE CAREFUL WITH THIS METHOD as it supposed that the content is not bigger than the provided widths.
     ///
@@ -36,7 +36,7 @@ impl TableDimension<'_> {
 
     /// Set rows heights.
     ///
-    /// In general the method is only considered to be usefull to a [`TableOption`].
+    /// In general the method is only considered to be useful to a [`TableOption`].
     ///
     /// BE CAREFUL WITH THIS METHOD as it supposed that the content is not bigger than the provided heights.
     ///

--- a/tabled/tests/derive_test.rs
+++ b/tabled/tests/derive_test.rs
@@ -382,7 +382,7 @@ mod enum_ {
     );
 
     test_enum!(
-        rename_all_enum_inhirited_inside_struct_enum,
+        rename_all_enum_inherited_inside_struct_enum,
         t: #[tabled(rename_all = "snake_case")] {
             #[tabled(inline)]
             VariantName1 { some_field_1: u8, some_field_2: i32 }
@@ -394,7 +394,7 @@ mod enum_ {
     );
 
     test_enum!(
-        rename_all_enum_inhirited_inside_struct_override_by_rename_enum,
+        rename_all_enum_inherited_inside_struct_override_by_rename_enum,
         t: #[tabled(rename_all = "snake_case")] {
             #[tabled(inline)]
             VariantName1 {
@@ -411,7 +411,7 @@ mod enum_ {
     );
 
     test_enum!(
-        rename_all_enum_inhirited_inside_struct_override_by_rename_all_enum,
+        rename_all_enum_inherited_inside_struct_override_by_rename_all_enum,
         t: #[tabled(rename_all = "snake_case")] {
             #[tabled(inline)]
             VariantName1 {
@@ -428,7 +428,7 @@ mod enum_ {
     );
 
     test_enum!(
-        rename_all_variant_inhirited_inside_struct_enum,
+        rename_all_variant_inherited_inside_struct_enum,
         t: #[tabled(rename_all = "snake_case")] {
             #[tabled(inline)]
             #[tabled(rename_all = "snake_case")]
@@ -444,7 +444,7 @@ mod enum_ {
     );
 
     test_enum!(
-        rename_all_variant_inhirited_inside_struct_enum_overridden_by_rename,
+        rename_all_variant_inherited_inside_struct_enum_overridden_by_rename,
         t: #[tabled(rename_all = "snake_case")] {
             #[tabled(inline, rename_all = "snake_case")]
             VariantName1 {
@@ -461,7 +461,7 @@ mod enum_ {
     );
 
     test_enum!(
-        rename_all_variant_inhirited_inside_struct_override_by_rename_all_enum,
+        rename_all_variant_inherited_inside_struct_override_by_rename_all_enum,
         t: #[tabled(rename_all = "snake_case")] {
             #[tabled(rename_all = "snake_case", inline)]
             VariantName1 {


### PR DESCRIPTION
Was going through this docs and noticed some spelling errors, so I corrected them.