### PR TITLE
update table shape with vec_records insert_row function

### DIFF
--- a/tabled/src/records/vec_records.rs
+++ b/tabled/src/records/vec_records.rs
@@ -135,6 +135,7 @@ where
     }
 
     fn insert_row(&mut self, row: usize) {
+        self.shape.0 += 1;
         self.data.insert(row, vec![T::default(); self.shape.1]);
     }
 }


### PR DESCRIPTION
This change will keep `records.count_rows()` up-to-date with the tables shape after row insertion.



# Criticism Welcome!
This bug was impacting my work on a new Split setting. If I've missing something obvious please let me know 😄 