### PR TITLE
add new function `insert_column` to Resizable trait

### DIFF
--- a/tabled/src/records/mod.rs
+++ b/tabled/src/records/mod.rs
@@ -101,8 +101,10 @@ pub trait Resizable {
     fn remove_row(&mut self, row: usize);
     /// Removes a column from a data set by index.
     fn remove_column(&mut self, column: usize);
-    /// Inserts a row to specific by row index.
+    /// Inserts a row at index.
     fn insert_row(&mut self, row: usize);
+    // Inserts column at index.
+    fn insert_column(&mut self, column: usize);
 }
 
 impl<'a, T> Resizable for &'a mut T
@@ -139,6 +141,10 @@ where
 
     fn insert_row(&mut self, row: usize) {
         T::insert_row(self, row)
+    }
+
+    fn insert_column(&mut self, column: usize) {
+        T::insert_column(self, column)
     }
 }
 
@@ -194,6 +200,12 @@ where
     fn insert_row(&mut self, row: usize) {
         let count_columns = self.get(0).map(|l| l.len()).unwrap_or(0);
         self.insert(row, vec![T::default(); count_columns]);
+    }
+
+    fn insert_column(&mut self, column: usize) {
+        for row in self {
+            row.insert(column, T::default());
+        }
     }
 }
 

--- a/tabled/src/records/mod.rs
+++ b/tabled/src/records/mod.rs
@@ -103,7 +103,7 @@ pub trait Resizable {
     fn remove_column(&mut self, column: usize);
     /// Inserts a row at index.
     fn insert_row(&mut self, row: usize);
-    // Inserts column at index.
+    /// Inserts column at index.
     fn insert_column(&mut self, column: usize);
 }
 

--- a/tabled/src/records/vec_records.rs
+++ b/tabled/src/records/vec_records.rs
@@ -138,6 +138,13 @@ where
         self.shape.0 += 1;
         self.data.insert(row, vec![T::default(); self.shape.1]);
     }
+
+    fn insert_column(&mut self, column: usize) {
+        self.shape.1 += 1;
+        for row in self.data.iter_mut() {
+            row.insert(column, T::default());
+        }
+    }
 }
 
 impl<T> RecordsMut<T> for VecRecords<T> {


### PR DESCRIPTION
I have a draft of Split ready to put up, but I needed to add this function to achieve all of the options discussed in https://github.com/zhiburt/tabled/issues/290. I figured it would be safer to split this dependent work into it's own PR so we can workshop any necessary changes you'd like to see before this goes in.


|          | Append | Zip    |
|:--------:|:------:|:------:|
| column(usize)   |   ✅    |   ✅    |
| row(usize)      |   ✅    | Requires changes in this PR |

---

P.S. I'm getting a yellow squiggly that says 
>missing documentation for an associated function

I'm not sure if that's referring to generated documentation online? I've added a doc comment above the function like insert_row().
https://github.com/zhiburt/tabled/blob/2319a19b0c80aa504476d68f2146211326bf43ed/tabled/src/records/mod.rs#L104-L105
I'm not sure what the difference is. I'm still learning about how Rust works 😅
