### PR TITLE
Better discoverability for `color` feature in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1358,8 +1358,24 @@ println!("{}", table);
 
 ### Color
 
-The library doesn't bind you in usage of any color library but to be able to work correctly with color input you should
-add the `color` feature of `tabled` to your `Cargo.toml`
+The library doesn't bind you in usage of any color library but to be able to work correctly with color input, and avoid [miscalculation of string width](https://github.com/zhiburt/tabled/issues/26) because of embedded ansi sequences, you should add the `color` feature of `tabled` to your `Cargo.toml`:
+
+```toml
+tabled = { version = "*", features = ["color"] } 
+```
+
+Then you can use colored strings as values:
+
+```rust
+use owo_colors::OwoColorize;
+// ...
+let mut builder = tabled::builder::Builder::default();
+builder.add_record(vec!["green".green(), "red".red()])
+let mut table = builder.build();
+table.with(tabled::Style::rounded());
+```
+
+Another example:
 
 ```rust
 use tabled::{format::Format, object::Columns, Modify, Style, Table};


### PR DESCRIPTION
Added another example, a link and hopefully larger surface area for people searching for a solution for working with colors inside a table. Took me quite a while to find that feature as i've searched for:

* broken ansi
* color in cell
* bad layout

and other search terms, just to hit issue #26 which deals with _hyperlinks_ ansi, but describes the problem well.

After I've used the color feature, everything works like magic!