### PR TITLE
Example description revisions

### DIFF
--- a/csv_to_table/examples/csv_table.rs
+++ b/csv_to_table/examples/csv_table.rs
@@ -3,7 +3,7 @@
 //! `cargo run --example csv_table`
 //!
 //! This example demonstrates reading a csv string to a [`Table`] struct.
-//! 
+//!
 //! ---
 //!
 //! * Note the necessary step of representing the string as a byte array.

--- a/csv_to_table/examples/csv_table.rs
+++ b/csv_to_table/examples/csv_table.rs
@@ -1,5 +1,12 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example csv_table`
+//!
+//! This example demonstrates reading a csv string to a [`Table`] struct.
+//! 
+//! ---
+//!
+//! * Note the necessary step of representing the string as a byte array.
 
 fn main() {
     let syscalls = "\

--- a/csv_to_table/examples/iter.rs
+++ b/csv_to_table/examples/iter.rs
@@ -2,13 +2,13 @@
 //!
 //! `cargo run --example iter`
 //!
-//! This example demonstrates an alternative parsing option for csv-to-table translations.
+//! This example demonstrates an alternative parsing option for [`csv_to_table`] translations.
 //!
 //! ---
 //! 
-//! * The formatting feature `sniff` is used to demonstrate how many
-//! rows will be considered in determining column widths.
-//! This is helpful for controlling large dataset display outputs.
+//! * The [`IterTable::sniff()`] formatting function is used to control how many
+//! rows will be considered in determining column widths. Since the default sniff value is 1000,
+//! this is helpful for controlling large dataset display outputs.
 
 fn main() {
     let syscalls = "\

--- a/csv_to_table/examples/iter.rs
+++ b/csv_to_table/examples/iter.rs
@@ -5,7 +5,7 @@
 //! This example demonstrates an alternative parsing option for [`csv_to_table`] translations.
 //!
 //! ---
-//! 
+//!
 //! * The [`IterTable::sniff()`] formatting function is used to control how many
 //! rows will be considered in determining column widths. Since the default sniff value is 1000,
 //! this is helpful for controlling large dataset display outputs.

--- a/csv_to_table/examples/iter.rs
+++ b/csv_to_table/examples/iter.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example iter`
+//!
+//! This example demonstrates an alternative parsing option for csv-to-table translations.
+//!
+//! ---
+//! 
+//! * The formatting feature `sniff` is used to demonstrate how many
+//! rows will be considered in determining column widths.
+//! This is helpful for controlling large dataset display outputs.
 
 fn main() {
     let syscalls = "\

--- a/json_to_table/examples/collapse.rs
+++ b/json_to_table/examples/collapse.rs
@@ -4,9 +4,9 @@
 //!
 //! This example demonstrates using the [`JsonTable::collapse`] function
 //! to greatly improve the readability of a [`JsonTable`].
-//! 
+//!
 //! ---
-//! 
+//!
 //! * Note that a [`JsonTable`] must be mutably defined to be collapsed.
 
 use json_to_table::json_to_table;

--- a/json_to_table/examples/json_to_table.rs
+++ b/json_to_table/examples/json_to_table.rs
@@ -1,13 +1,13 @@
 //! This example can be run with the following command:
 //!
-//! `cargo run --example collapse`
+//! `cargo run --example json_to_table`
 //!
-//! This example demonstrates using the [`JsonTable::collapse`] function
-//! to greatly improve the readability of a [`JsonTable`].
-//! 
+//! This example demonstrates parsing a JSON literal to a [`Value`],
+//! and then translating that value to a [`JsonTable`] struct.
+//!
 //! ---
 //! 
-//! * Note that a [`JsonTable`] must be mutably defined to be collapsed.
+//! * Note how the [`json_to_table`] function is used for easy translations.
 
 use json_to_table::json_to_table;
 
@@ -25,8 +25,7 @@ fn main() {
         ],
     });
 
-    let mut table = json_to_table(&json);
-    table.collapse();
+    let table = json_to_table(&json);
 
     println!("{table}");
 }

--- a/json_to_table/examples/json_to_table.rs
+++ b/json_to_table/examples/json_to_table.rs
@@ -6,7 +6,7 @@
 //! and then translating that value to a [`JsonTable`] struct.
 //!
 //! ---
-//! 
+//!
 //! * Note how the [`json_to_table`] function is used for easy translations.
 
 use json_to_table::json_to_table;

--- a/json_to_table/examples/orientation.rs
+++ b/json_to_table/examples/orientation.rs
@@ -8,7 +8,7 @@
 //! - [`JsonTable::set_array_mode`]
 //! - [`JsonTable::set_object_mode`]
 //! - [`JsonTable::set_mode_visitor`]
-//! 
+//!
 //! ---
 //!
 //! * Note the shared [`Orientation`] enum between these methods.

--- a/json_to_table/examples/orientation.rs
+++ b/json_to_table/examples/orientation.rs
@@ -1,5 +1,17 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example orientation`
+//!
+//! This example demonstrates several [`JsonTable`] functions for rotating
+//! the arrangement of keys and values with the following functions:
+//!
+//! - [`JsonTable::set_array_mode`]
+//! - [`JsonTable::set_object_mode`]
+//! - [`JsonTable::set_mode_visitor`]
+//! 
+//! ---
+//!
+//! * Note the shared [`Orientation`] enum between these methods.
 
 use json_to_table::{json_to_table, Orientation};
 

--- a/json_to_table/examples/reader.rs
+++ b/json_to_table/examples/reader.rs
@@ -1,17 +1,23 @@
-//! This example reads a json from STDIN and build a table out of it.
+//! This example can be run with the following command:
 //!
-//! Example usage.
+//! `cat some_interesting_data.json | cargo run --example reader -- --collapse`
 //!
-//! ```
-//! cat some_interesting_data.json | cargo run --example reader -- --collapse
-//! ```
+//! This example demonstrates parsing json from the [`Stdin`]\(standard input) to a [`JsonTable`].
+//!
+//! ---
+//!
+//! * Check out [`serde_json`] for other helpful ways to import json data into your project.
+//! * Check out [`std::env`] and [`std::io`] for more examples of dealing with system streams.
+//! * Windows alternatives for the unix `cat` command:
+//!     - `type` for command prompt
+//!     - `get-content` for powershell
 
-use std::io;
+use std::{env, io};
 
 use json_to_table::json_to_table;
 
 fn main() {
-    let use_collapse = std::env::args().any(|arg| &arg == "--collapse");
+    let use_collapse = env::args().any(|arg| &arg == "--collapse");
 
     let stdin = io::stdin();
     let value = serde_json::from_reader(stdin).expect("failed to read stdin");

--- a/papergrid/examples/color_map.rs
+++ b/papergrid/examples/color_map.rs
@@ -1,7 +1,15 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --features color --example color_map`
 //!
-//! This example requires the `color` feature.
+//! This example demonstrates using a [`HashMap`] of colors to simplify styling
+//! sections of a [`Grid`] without embedding ANSI escape characters into cell values.
+//!
+//! ---
+//!
+//! * 🚩 This example requires the `color` feature.
+//!
+//! * Check out [`owo_colors`] for additional styling options available through their API.
 
 use std::{
     collections::HashMap,

--- a/papergrid/examples/colored_border.rs
+++ b/papergrid/examples/colored_border.rs
@@ -1,7 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --features color --example colored_border`
 //!
-//! This example requires the `color` feature.
+//! This example demonstrates using colors to stylize [`Grid`] borders.
+//! Borders can be set globally with [`SpannedConfig::set_border_color_global()`]
+//! or individually with [`SpannedConfig::set_border_color()`].
+//!
+//! ---
+//!
+//! * 🚩 This example requires the `color` feature.
+//!
+//! * [`CompactConfig`] also supports colorization when the `color` feature is enabled.
 
 use papergrid::{
     color::AnsiColor,
@@ -18,7 +27,7 @@ fn main() {
     let cfg = generate_table_config();
 
     let data = vec![
-        vec!["Papergrid", "is a library", "for print tables", "!"],
+        vec!["Papergrid", "is a library", "for printing tables", "!"],
         vec!["", "Just like this", "", ""],
     ];
     let records = IterRecords::new(data, 4, Some(2));

--- a/papergrid/examples/common_grid.rs
+++ b/papergrid/examples/common_grid.rs
@@ -1,5 +1,15 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example common_grid`
+//!
+//! This example demonstrates the flexibility of [`papergrid`] with manual configurations
+//! of [`Borders`], [`CompactConfig`], and column counts with [`IterRecords`].
+//!
+//! ---
+//!
+//! * For an alternative to [`CompactGrid`] and [`CompactGridDimension`] with
+//! flexible row height, variable intra-column spans, and multiline cell support
+//! see [`Grid`] and [`SpannedGridDimension`].
 
 use papergrid::{
     config::compact::CompactConfig,
@@ -14,7 +24,7 @@ fn main() {
     let cfg = generate_table_config();
 
     let data = [
-        ["Papergrid", "is a library", "for print tables", "!"],
+        ["Papergrid", "is a library", "for printing tables", "!"],
         [
             "Just like this",
             "NOTICE",

--- a/papergrid/examples/common_grid_no_std.rs
+++ b/papergrid/examples/common_grid_no_std.rs
@@ -1,5 +1,12 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example common_grid_no_std`
+//!
+//! This example demonstrates using [`papergrid`] without [The Rust Standard Library](std).
+//!
+//! ---
+//!
+//! * Note the missing, pre-built [`Dimension`] implementations requiring manual design.
 
 use papergrid::{
     config::compact::CompactConfig,
@@ -11,7 +18,7 @@ use papergrid::{
 
 fn main() {
     let data = [
-        ["Papergrid", "is a library", "for print tables", "!"],
+        ["Papergrid", "is a library", "for printing tables", "!"],
         [
             "Just like this",
             "NOTICE",

--- a/papergrid/examples/hello_world.rs
+++ b/papergrid/examples/hello_world.rs
@@ -1,5 +1,19 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example hello_world`
+//!
+//! This example demonstrates the flexibility of [`papergrid`] with manual configurations
+//! of [`Borders`], [`SpannedConfig`], and column counts with [`IterRecords`].
+//!
+//! ---
+//!
+//! * For an alternative to [`Grid`] and [`SpannedGridDimension`] with
+//! uniform row height and intra-column spans see [`CompactGrid`] and [`CompactGridDimension`].
+//!
+//! * Note that [`Grid`] supports multiline cells whereas [`CompactGrid`] does not.
+//!
+//! * Note that [`Dimension`] implementations rely on [`Dimension::estimate()`]
+//! to correctly format outputs, and typically trigger index-out-of-bounds errors otherwise.
 
 use papergrid::{
     colors::NoColors,
@@ -15,8 +29,13 @@ fn main() {
     let cfg = generate_table_config();
 
     let data = [
-        ["Papergrid", "is a library", "for print tables", "!"],
-        ["", "Just like this", "", ""],
+        ["Papergrid", "is a library", "for printing tables", "!"],
+        [
+            "",
+            "Just                                     like\n\nthis",
+            "",
+            "",
+        ],
     ];
     let records = IterRecords::new(data, 4, None);
 

--- a/papergrid/examples/papergrid_color.rs
+++ b/papergrid/examples/papergrid_color.rs
@@ -1,7 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --features color --example papergrid_color`
 //!
-//! This example requires the `color` feature.
+//! This example demonstrates using colors to stylize [`Grid`] cells.
+//!
+//! ---
+//!
+//! * 🚩 This example requires the `color` feature.
+//!
+//! * Note that this example uses inline ANSI escape characters to style
+//! grid cells. `Grid::new(_, _, _, NoColors)` indicates that a color
+//! map is not provided. NOT that colors are ignored in the output.
 
 use std::io::Write;
 

--- a/static_table/examples/static_table.rs
+++ b/static_table/examples/static_table.rs
@@ -1,5 +1,21 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example static_table`
+//!
+//! This example demonstrates using the powerful [`static_table!`] macro to translate
+//! a sequence of arrays and several, optional settings to a static [`str`] table representation.
+//!
+//! ---
+//!
+//! * Note that [`static_table!`] is evaluated at compile time,
+//! resulting in highly efficient runtime performance.
+//!
+//! * [`static_table!`] supports configuration of:
+//!     * granular column and row span specification
+//!     * [`THEME`](tabled::settings::Style)
+//!     * [`ALIGNMENT`](tabled::settings::Alignment)
+//!     * [`PADDING`](`tabled::settings::Padding`)
+//!     * [`MARGIN`](tabled::settings::Margin)
 
 use static_table::static_table;
 

--- a/static_table/src/lib.rs
+++ b/static_table/src/lib.rs
@@ -1,4 +1,4 @@
-//! Library provides a macros to build a table at a compile time.
+//! This library provides a macro to build a table at compile time.
 //!
 //! # Get started
 //!

--- a/table_to_html/examples/html.rs
+++ b/table_to_html/examples/html.rs
@@ -1,5 +1,21 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example html`
+//!
+//! This example demonstrates using [`HtmlTable`] to easily transform a multi-dimensional array
+//! into web-friendly [html](https://developer.mozilla.org/en-US/docs/Web/HTML).
+//!
+//! ---
+//!
+//! * Note how [`HtmlTable::set_border()`] is used to customize the output markup.
+//! These changes are implemented through a prepended [style](https://developer.mozilla.org/en-US/docs/Web/css)
+//! section above the opening table tag.
+//!
+//! * Customization options include:
+//!     * Border
+//!     * Alignment
+//!     * Column and Row span
+//!     * Margin and Padding
 
 use table_to_html::HtmlTable;
 

--- a/tabled/Cargo.toml
+++ b/tabled/Cargo.toml
@@ -18,11 +18,16 @@ coveralls = { repository = "https://github.com/zhiburt/tabled", branch = "master
 maintenance = { status = "actively-developed" }
 
 [[example]]
+name = "color"
+required-features = ["color", "derive"]
+
+[[example]]
 name = "colored_borders"
 required-features = ["derive"]
 
 [[example]]
-name = "color"
+name = "colored_padding"
+path = "examples/colored_padding.rs"
 required-features = ["color", "derive"]
 
 [[example]]
@@ -123,11 +128,6 @@ required-features = ["derive"]
 name = "nested_table_3"
 path = "examples/nested_table_3.rs"
 required-features = ["derive"]
-
-[[example]]
-name = "padding_color"
-path = "examples/padding_color.rs"
-required-features = ["color", "derive"]
 
 [[example]]
 name = "col_row_macros"

--- a/tabled/examples/alphabet.rs
+++ b/tabled/examples/alphabet.rs
@@ -1,5 +1,13 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example alphabet`
+//!
+//! This example demonstrates instantiating a [`Table`] from an [`IntoIterator`] compliant object.
+//!
+//! ---
+//!
+//! * Note how [`Range`] [expression syntax](https://doc.rust-lang.org/reference/expressions/range-expr.html)
+//! is used to idiomatically represent the English alphabet.
 
 use std::iter::FromIterator;
 

--- a/tabled/examples/border_text.rs
+++ b/tabled/examples/border_text.rs
@@ -1,5 +1,28 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example border_text`
+//!
+//! This example demonstrates inserting text into the borders
+//! of a [`Table`] with [`BorderText`]; a powerful labeling tool.
+//!
+//! ---
+//!
+//! * [`BorderText`] currently supports:
+//!     * Horizontal border placement
+//!     * Placement starting column offset
+//!     * Text colorization
+//!
+//! * Note how the flexibility of [`Style`] is utilized
+//! to remove horizontal borders from the table entirely,
+//! and then granularly reinserts one for a highly customized
+//! visualization.
+//!
+//! * Note how the [`Rows`] utility object is used to idiomatically
+//! reference the first and last rows of a [`Table`] without writing
+//! the necessary logic by hand.
+//!
+//! * 🚀 Combining several easy-to-use tools,
+//! to create unique data representations is what makes [`tabled`] great!
 
 use tabled::{
     settings::{

--- a/tabled/examples/builder.rs
+++ b/tabled/examples/builder.rs
@@ -1,5 +1,18 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example builder`
+//!
+//! This example demonstrates an alternative method for creating a [`Table`].
+//! [`Builder`] is an efficient implementation of the [builder design pattern](https://en.wikipedia.org/wiki/Builder_pattern).
+//!
+//! > The intent of the Builder design pattern is to separate the construction of a complex object from its representation.
+//! > -- <cite>Wikipedia</cite>
+//!
+//! ---
+//!
+//! * Note how [Builder] can be used to define a table's shape manually
+//!  and can be populated through iteration if it is mutable. This flexibility
+//! is useful when you don't have direct control over the datasets you intend to [table](tabled).
 
 use tabled::{
     builder::Builder,

--- a/tabled/examples/builder_index.rs
+++ b/tabled/examples/builder_index.rs
@@ -1,5 +1,19 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example builder_index`
+//!
+//! This example demonstrates evolving the standard [`Builder`] to an [`IndexBuilder`],
+//! and then manipulating the constructing table with a newly prepended index column.
+//!
+//! ---
+//!
+//! * An [`IndexBuilder`] is capable of several useful manipulations, including:
+//!     * Giving the new index column a name
+//!     * Transposing the index column around a table
+//!     * Choosing a location for the new index column besides 0; the default
+//!
+//! * Note that like with any builder pattern the [`IndexBuilder::build()`] function
+//! is necessary to produce a displayable [`Table`].
 
 use tabled::{settings::Style, Table, Tabled};
 

--- a/tabled/examples/col_row_macros.rs
+++ b/tabled/examples/col_row_macros.rs
@@ -2,16 +2,16 @@
 //!
 //! `cargo run --features macros --example col_row_macros`
 //!
-//! This example demonstrates using the [`col!`] and [`row!`] macros to easily 
+//! This example demonstrates using the [`col!`] and [`row!`] macros to easily
 //! organize multiple tables together into a single, new [`Table`] display.
-//! 
+//!
 //! ---
-//! 
+//!
 //! * 🚩 This example requires the `macros` feature.
-//! 
-//! * Note how both macros can be used in combination to layer 
+//!
+//! * Note how both macros can be used in combination to layer
 //! several table arrangements together.
-//! 
+//!
 //! * Note how [`col!`] and [`row!`] support idiomatic argument duplication
 //! with the familiar `[T; N]` syntax.
 

--- a/tabled/examples/col_row_macros.rs
+++ b/tabled/examples/col_row_macros.rs
@@ -1,7 +1,19 @@
-//! The example can be run by this command
-//! `cargo run --example col_row_macros --features macros`
+//! This example can be run with the following command:
 //!
-//! This example requires the `macros` feature.
+//! `cargo run --features macros --example col_row_macros`
+//!
+//! This example demonstrates using the [`col!`] and [`row!`] macros to easily 
+//! organize multiple tables together into a single, new [`Table`] display.
+//! 
+//! ---
+//! 
+//! * 🚩 This example requires the `macros` feature.
+//! 
+//! * Note how both macros can be used in combination to layer 
+//! several table arrangements together.
+//! 
+//! * Note how [`col!`] and [`row!`] support idiomatic argument duplication
+//! with the familiar `[T; N]` syntax.
 
 use tabled::{
     col, row,

--- a/tabled/examples/color.rs
+++ b/tabled/examples/color.rs
@@ -1,7 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --features color --example color`
 //!
-//! This example requires the `color` feature.
+//! This example demonstrates using the [`Color`] [setting](tabled::settings) to
+//! stylize text, backgrounds, and borders.
+//!
+//! ---
+//!
+//! * 🚩 This example requires the `color` feature.
+//!
+//! * Note how [`Format::content()`] is used to break out [`CellOption`]
+//! specifications. This is helpful for organizing extensive [`Table`] configurations.
 
 use std::convert::TryFrom;
 

--- a/tabled/examples/colored_borders.rs
+++ b/tabled/examples/colored_borders.rs
@@ -1,7 +1,17 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --features color --example colored_borders`
 //!
-//! This example requires the `color` feature.
+//! This example demonstrates using the [`RawStyle`] [setting](tabled::settings) to
+//! to granularly specify border colors.
+//!
+//! ---
+//!
+//! * 🚩 This example requires the `color` feature.
+//!
+//! * Note how [`Color`] containts several helpful, const values covering
+//! a basic selection of foreground and background colors. [`Color`] also
+//! supports custom colors with [`Color::new()`].
 
 use tabled::{
     settings::{

--- a/tabled/examples/colored_padding.rs
+++ b/tabled/examples/colored_padding.rs
@@ -1,17 +1,17 @@
 //! This example can be run with the following command:
 //!
-//! `cargo run --features color --example padding_color`
+//! `cargo run --features color --example colored_padding`
 //!
 //! This example demonstrates using the [`Padding::colorize()`] function in several ways
 //! to give a [`Table`] display a vibrant asthetic.
-//! 
+//!
 //! ---
-//! 
+//!
 //! * 🚩 This example requires the `color` feature.
-//! 
+//!
 //! * Note how the [`Color`] [setting](tabled::settings) is used to simplify creating
-//! reusable themes for text backgrounds, padded whitespace, and borders.
-//! 
+//! reusable themes for text, backgrounds, padded whitespace, and borders.
+//!
 //! * Note how a unique color can be set for each direction.
 
 use std::convert::TryFrom;

--- a/tabled/examples/compact_table.rs
+++ b/tabled/examples/compact_table.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example compact_table`
+//!
+//! This example demonstrates creating a `new()` [`CompactTable`] with
+//! manual specifications for column count, column widths, and border styling.
+//!
+//! ---
+//!
+//! * [`CompactTable`] is a [`Table`] alternative that trades off reduced
+//! flexibility for improved performance.
 
 use tabled::{settings::Style, tables::CompactTable};
 

--- a/tabled/examples/compact_table_2.rs
+++ b/tabled/examples/compact_table_2.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example compact_table_2`
+//!
+//! This example demonstrates creating a [`CompactTable`] `from()` a
+//! multidimensional array.
+//!
+//! ---
+//!
+//! * Note how [`CompactTable::from()`] inherits the lengths of the nested arrays
+//! as typed definitions through [const generics](https://practice.rs/generics-traits/const-generics.html).
 
 use tabled::{settings::Style, tables::CompactTable};
 

--- a/tabled/examples/compact_table_3.rs
+++ b/tabled/examples/compact_table_3.rs
@@ -1,5 +1,13 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example compact_table_3`
+//!
+//! This example demonstrates how [`CompactTable`] is limited to single
+//! line rows.
+//!
+//! ---
+//!
+//! * Note how the multiline data is accepted, but then truncated in the display.
 
 use tabled::{settings::Style, tables::CompactTable};
 

--- a/tabled/examples/concat.rs
+++ b/tabled/examples/concat.rs
@@ -1,5 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example concat`
+//!
+//! This example demonstrates using the [`Concat`] [`TableOption`] to concatenate
+//! [`tables`](Table) together.
+//!
+//! ---
+//!
+//! * [`Concat`] supports appending tables vertically and horizontally.
+//!
+//! * Note how the base tables style settings take take precedence over the appended table.
+//! If the two tables are of unequal shape, additional blank cells are added as needed.
 
 use tabled::{
     settings::{object::Segment, Alignment, Concat, Modify, Style},

--- a/tabled/examples/custom_style.rs
+++ b/tabled/examples/custom_style.rs
@@ -1,5 +1,17 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example custom_style`
+//!
+//! This example demonstrates customizing one of the [`tabled`] default [styles](Style)
+//! to create a unique [`Table`] display.
+//!
+//! ---
+//!
+//! * Note that all predesigned styles can be configured completely.
+//! Styles can also be created from scratch!
+//!
+//! * Note that adding and removing borders with a [`Style`] theme doesn't affect the
+//! number of functional columns and rows.
 
 use tabled::{
     settings::{

--- a/tabled/examples/derive/display_with.rs
+++ b/tabled/examples/derive/display_with.rs
@@ -1,5 +1,20 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example display_with`
+//!
+//! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
+//! [`display_with`] to seamlessly augment field representations in a [`Table`] display.
+//!
+//! ---
+//!
+//! * [`display_with`] functions act as transformers during [`Table`] instantiation.
+//!
+//! * Note how [`display_with`] works with [std] and custom functions alike.
+//!
+//! * [`display_with`] attributes can be constructed in two ways (shown below).
+//!
+//! * Attribute arguments can be directly overridden with static values, effectively ignoring the
+//! augmented fields natural value entirely. Even an entire object can be passed as context with `self`.
 
 use std::borrow::Cow;
 

--- a/tabled/examples/derive/inline.rs
+++ b/tabled/examples/derive/inline.rs
@@ -1,5 +1,15 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example inline`
+//!
+//! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
+//! [`inline`] to expand struct fields to individual columns in a [`Table`] display.
+//!
+//! ---
+//!
+//! * Note that without inlining a struct or enum field, those objects
+//! must implement the [`Display`] trait as they will be represented in
+//! a single column with the value of their [`ToString`] output.
 
 use tabled::{Table, Tabled};
 

--- a/tabled/examples/derive/inline_enum.rs
+++ b/tabled/examples/derive/inline_enum.rs
@@ -1,5 +1,19 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example inline_enum`
+//!
+//! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
+//! [`inline`] to expand enum fields to individual columns in a [`Table`] display.
+//!
+//! ---
+//!
+//! * Note how the optional [`inline`] argument is used to apply prefixes
+//! to decomposed column headers. This is helpful for organizing tables
+//! with repetative fields that would normally result in confusing headers.
+//!
+//! * Note that without inlining a struct or enum field, those objects
+//! must implement the [`Display`] trait as they will be represented in
+//! a single column with the value of their [`ToString`] output.
 
 use tabled::{Table, Tabled};
 

--- a/tabled/examples/derive/order.rs
+++ b/tabled/examples/derive/order.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example order`
+//!
+//! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
+//! [`order`] to relocate fields to specified indexes in a [`Table`] display.
+//!
+//! ---
+//!
+//! * By default, [`Table`] columns are shown in the same ordered they are
+//! defined in the deriving struct/enum definition.
 
 use tabled::{Table, Tabled};
 

--- a/tabled/examples/derive/rename.rs
+++ b/tabled/examples/derive/rename.rs
@@ -1,5 +1,9 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example rename`
+//!
+//! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
+//! [`rename`] to alias specific fields in a [`Table`] display.
 
 use tabled::{Table, Tabled};
 

--- a/tabled/examples/derive/rename_all.rs
+++ b/tabled/examples/derive/rename_all.rs
@@ -1,5 +1,21 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example rename_all`
+//!
+//! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
+//! [`rename_all`] to apply table-wide header formatting in a [`Table`] display.
+//!
+//! ---
+//!
+//! * Supported formatting rules include:
+//!     * 'camelCase'
+//!     * 'kabab-case'
+//!     * 'PascalCase'
+//!     * 'SCREAMING_SNAKE_CASE'
+//!     * 'snake_case'
+//!     * 'lowercase'
+//!     * 'UPPERCASE'
+//!     * 'verbatim'
 
 use tabled::{Table, Tabled};
 

--- a/tabled/examples/derive/skip.rs
+++ b/tabled/examples/derive/skip.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example skip`
+//!
+//! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
+//! [`skip`] to omit specific fields from becoming columns in a [`Table`] display.
+//!
+//! ---
+//!
+//! * Note how [`skip`] annoys [clippy](https://doc.rust-lang.org/clippy/) with `dead_code`
+//! warnings. This can be addressed with compiler overrides like `#[allow(dead_code)]`.
 
 use tabled::{Table, Tabled};
 

--- a/tabled/examples/disable.rs
+++ b/tabled/examples/disable.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example disable`
+//!
+//! This example demonstrates using the [`Disable`] [`TableOption`] to remove specific
+//! cell data from a [`Table`] display.
+//!
+//! ---
+//!
+//! * ⚠️ Using [`Disable`] in combination with other [`Style`] customizations may yield unexpected results.
+//! It is safest to use [`Disable`] last in a chain of alterations.
 
 use tabled::{
     settings::{

--- a/tabled/examples/extended_display.rs
+++ b/tabled/examples/extended_display.rs
@@ -1,5 +1,13 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example extended_display`
+//!
+//! This example demonstrates using [ExtendedTable], a [Table] alternative with
+//! limited flexibility but a greater emphasis on large data displays.
+//!
+//! ---
+//!
+//! * 🎉 Inspired by https://www.postgresql.org/docs/current/app-psql.html
 
 use tabled::{tables::ExtendedTable, Tabled};
 

--- a/tabled/examples/extract.rs
+++ b/tabled/examples/extract.rs
@@ -1,5 +1,19 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example extract`
+//!
+//! This example demonstrates using the [`Extract`] [`TableOption`] to
+//! produce a subsection of a [`Table`].
+//!
+//! ---
+//!
+//! * [`Extract`] can return a new [`Table`] with three functions:
+//!     * `rows()` | yields subset of the initial rows
+//!     * `columns()` | yields subset of the initial columns
+//!     * `segment()` | yields subsection of the initial table
+//!
+//! * Note how [`Extract`] methods accepts [`RangeBounds`] arguments,
+//! making subset specifications concise.
 
 use std::fmt::{Display, Formatter};
 

--- a/tabled/examples/format.rs
+++ b/tabled/examples/format.rs
@@ -1,7 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example format`
 //!
-//! The example shows a usage of [`tabled::Format`]/[`tabled::FormatWithIndex`].
+//! This example demonstrates using the [`Format`] [`CellOption`] factory to alter
+//! the cells of a [`Table`].
+//!
+//! ---
+//!
+//! * Note how [`Format::content()`] gives access to the respective cell content for replacement.
+//! And [`Format::positioned()`] additionally provides the index coordinates of that cell.
+//!
+//! * Note how the [std] [`format!`] macro is used to update the values of the affected cells.
 
 use tabled::{
     settings::{

--- a/tabled/examples/formatting_settings.rs
+++ b/tabled/examples/formatting_settings.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example formatting_settings`
+//!
+//! This example demonstrates using the [`Alignment`], [`AlignmentStrategy`], and [`TrimStrategy`] [`CellOptions`]
+//! to align the content of a [`Table`] in several nuanced ways.
+//!
+//! ---
+//!
+//! * Note how [`AlignmentStrategy`] and [`TrimStrategy`] provide useful tools for managing multiline cells and
+//! cell values that are bloated with whitespace.
 
 use tabled::{
     settings::{

--- a/tabled/examples/grid_colors.rs
+++ b/tabled/examples/grid_colors.rs
@@ -1,9 +1,14 @@
-//! We can set colors for particular cells by using [`Grid`]
+//! This example can be run with the following command:
 //!
-//! The example can be run by this command
 //! `cargo run --example grid_colors`
 //!
-//! [`Grid`]: tabled::grid::Grid
+//! This example demonstrates using [`Color`] as a [`CellOption`] modifier to stylize
+//! the cells of a [`Table`].
+//!
+//! ---
+//!
+//! * Note how the [`Color`] [setting](tabled::settings) is used to simplify creating
+//! reusable themes for backgrounds.
 
 use tabled::{
     settings::{Color, Modify, Style},

--- a/tabled/examples/height.rs
+++ b/tabled/examples/height.rs
@@ -1,5 +1,20 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example height`
+//!
+//! This example demonstrates using the [`Height`] [`TableOption`] for adjusting
+//! the height of a [`Table`].
+//!
+//! ---
+//!
+//! * [`Height`] supports three key features:
+//!     * [`CellHeightIncrease`] spreads new whitespace between the [`Table`]
+//! rows up to the specified line count.
+//!     * [`CellHeightLimit`] removes lines from the [`Table`] rows fairly, until
+//! it has no choice but to remove single-line-rows entirely, bottom up.
+//!     * [`HeightList`] accepts an array of height specifications that are applied
+//! to the rows with the same index. This is helpful for granularly specifying individual
+//! row heights irrespective of [`Padding`] or [`Margin`].
 
 use tabled::{
     settings::{peaker::PriorityMax, Height, Style},

--- a/tabled/examples/highlight.rs
+++ b/tabled/examples/highlight.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example highlight`
+//!
+//! This example demonstrates using the [`Highlight`] [`TableOption`] to
+//! decorate sections of a [`Table`] with a unique [`Border`].
+//!
+//! ---
+//!
+//! * Note how [`Highlight`] arguments can be chained together to
+//! create cross-sections and non-symmetrical shapes.
 
 use tabled::{
     settings::{

--- a/tabled/examples/highlight_color.rs
+++ b/tabled/examples/highlight_color.rs
@@ -1,5 +1,13 @@
-//! The example can be run by this command
-//! `cargo run --example highlight_color`
+//! This example can be run with the following command:
+//!
+//! `cargo run --example highlight`
+//!
+//! This example demonstrates using [`Highlight`] in combination with [`BorderColor`] to
+//! frame sections of a [`Table`] with a unique background [`Color`].
+//!
+//! ---
+//!
+//! * Note how [`Highlight::colored()`] is used to accept the necessary input instead of [`Highlight::new()`].
 
 use tabled::{
     settings::{

--- a/tabled/examples/hyperlink.rs
+++ b/tabled/examples/hyperlink.rs
@@ -1,7 +1,18 @@
-//! To run this example:
+//! This example can be run with the following command:
+//!
 //! `cargo run --features color --example hyperlink`
 //!
-//! This example requires the `color` feature.
+//! This example demonstrates how hyperlinks can be embedded into a [`Table`] display.
+//!
+//! While not a [`tabled`] specific implementation, it is helpful to know that
+//! most users expect certain elements of interactivity based on the purpose of your display.
+//!
+//! ---
+//!
+//! * 🚩 This example requires the `color` feature.
+//!
+//! * ⚠️ Terminal interfaces may differ in how they parse links or make them interactive.
+//! [`tabled`] doesn't have the final say on whether a link is clickable or not.
 
 use tabled::{
     settings::{object::Segment, Alignment, Modify, Style, Width},

--- a/tabled/examples/iter_table.rs
+++ b/tabled/examples/iter_table.rs
@@ -1,5 +1,21 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example iter_table`
+//!
+//! This example demonstrates using [`IterTable`], an [allocation](https://doc.rust-lang.org/nomicon/vec/vec-alloc.html)
+//! free [`Table`] alternative that translates an iterator into a display.
+//!
+//! ---
+//!
+//! * Note how [`IterTable`] supports the familiar `.with()` syntax for applying display
+//! modifications.
+//!
+//! * [`IterTable`] supports manual configuration of:
+//!     * Record sniffing (default 1000 rows)
+//!     * Row cutoff
+//!     * Row height
+//!     * Column cutoff
+//!     * Column width
 
 use std::io::BufRead;
 

--- a/tabled/examples/margin.rs
+++ b/tabled/examples/margin.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example margin`
+//!
+//! This example demonstrates using the [`Margin`] [`TableOption`] to buffer space
+//! around a [`Table`] display.
+//!
+//! ---
+//!
+//! * Note how the [`Margin::fill()`] function allows for overriding the default whitespace
+//! with any [`char`].
 
 use tabled::{
     settings::{Margin, Style},

--- a/tabled/examples/matrix.rs
+++ b/tabled/examples/matrix.rs
@@ -15,6 +15,7 @@ use tabled::{settings::Style, Table};
 fn matrix<const N: usize>() -> [[usize; N]; N] {
     let mut matrix = [[0; N]; N];
 
+    #[allow(clippy::needless_range_loop)]
     for i in 0..N {
         for j in 0..N {
             matrix[i][j] = (i + 1) * (j + 1);

--- a/tabled/examples/matrix.rs
+++ b/tabled/examples/matrix.rs
@@ -1,12 +1,20 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example matrix`
+//!
+//! This example demonstrates how [`tabled`] is an excellent tool for creating
+//! dataset visualizations.
+//!
+//! ---
+//!
+//! * 🚀 When native display solutions, such as the [`Debug`] trait and [pretty printing](https://doc.rust-lang.org/std/fmt/#sign0)
+//! options, aren't enough, [`tabled`] is a great choice for improving the quality of your displays.
 
 use tabled::{settings::Style, Table};
 
 fn matrix<const N: usize>() -> [[usize; N]; N] {
     let mut matrix = [[0; N]; N];
 
-    #[allow(clippy::needless_range_loop)]
     for i in 0..N {
         for j in 0..N {
             matrix[i][j] = (i + 1) * (j + 1);

--- a/tabled/examples/merge_duplicates.rs
+++ b/tabled/examples/merge_duplicates.rs
@@ -1,5 +1,19 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example merge_duplicates`
+//!
+//! This example demonstrates using the [`Merge`] [`TableOption`] to clarify
+//! redundancies in a [`Table`] display.
+//!
+//! ---
+//!
+//! * Note how repetative entries must be consecutive, in their specified direction,
+//! to be merged together.
+//!
+//! * Note how [`BorderSpanCorrection`] is used to resolve display issues incurred
+//! from [`Span`] decisions made through duplicate detection.
+//!
+//! * Merge supports both [`Merge::vertical()`] and [`Merge::horizontal()`].
 
 use tabled::{
     settings::{

--- a/tabled/examples/merge_duplicates_2.rs
+++ b/tabled/examples/merge_duplicates_2.rs
@@ -1,5 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example merge_duplicates_2`
+//!
+//! This example demonstrates using the [`Merge`] [`TableOption`] to clarify
+//! redundancies in a [`Table`] display.
+//!
+//! ---
+//!
+//! * Note how a custom theme is applied to give the [`Merged`](Merge) cells
+//! a unique look.
+//!
+//! * Merge supports both [`Merge::vertical()`] and [`Merge::horizontal()`].
 
 use tabled::{
     settings::{

--- a/tabled/examples/nested_table.rs
+++ b/tabled/examples/nested_table.rs
@@ -1,7 +1,17 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example nested_table`
 //!
-//! The table is a take on the one from https://github.com/p-ranav/tabulate#nested-tables/
+//! This example demonstrates how [`Tables`](Table) can be comprised of other tables.
+//!
+//! ---
+//!
+//! * This first nested [`Table`] example showcases the [`Builder`] approach.
+//!
+//! * Note how a great deal of manual customizations have been applied to create a
+//! highly unique display.
+//!
+//! * 🎉 Inspired by https://github.com/p-ranav/tabulate#nested-tables/
 
 use std::iter::FromIterator;
 

--- a/tabled/examples/nested_table_2.rs
+++ b/tabled/examples/nested_table_2.rs
@@ -1,5 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example nested_table_2`
+//!
+//! This example demonstrates a minimalist implementation of [`Tabling`](Table) records
+//! with struct fields.
+//!
+//! ---
+//!
+//! * This second nested [`Table`] example showcases the [`derive`] approach.
+//!
+//! * Note how the [`display_with`] attribute macro applies the custom `display_distribution`
+//! filter function, which, in this case, applies styles to the final display.
 
 use tabled::{settings::Style, Table, Tabled};
 

--- a/tabled/examples/nested_table_3.rs
+++ b/tabled/examples/nested_table_3.rs
@@ -1,5 +1,13 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example nested_table_3`
+//!
+//! This example demonstrates creating a nested [`Table`] by instantiating a new
+//! [`Table`] from a collection of other [`Tables`](Table).
+//!
+//! ---
+//!
+//! * This third nested [`Table`] example showcases the [`Table::new()`] approach.
 
 use tabled::{
     settings::{

--- a/tabled/examples/padding_color.rs
+++ b/tabled/examples/padding_color.rs
@@ -1,8 +1,18 @@
-//! The example can be run by this command.
+//! This example can be run with the following command:
 //!
 //! `cargo run --features color --example padding_color`
 //!
-//! This example requires the `color` feature.
+//! This example demonstrates using the [`Padding::colorize()`] function in several ways
+//! to give a [`Table`] display a vibrant asthetic.
+//! 
+//! ---
+//! 
+//! * 🚩 This example requires the `color` feature.
+//! 
+//! * Note how the [`Color`] [setting](tabled::settings) is used to simplify creating
+//! reusable themes for text backgrounds, padded whitespace, and borders.
+//! 
+//! * Note how a unique color can be set for each direction.
 
 use std::convert::TryFrom;
 

--- a/tabled/examples/panel.rs
+++ b/tabled/examples/panel.rs
@@ -1,5 +1,17 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example panel`
+//!
+//! This example demonstrates using the [`Panel`] [`TableOption`] to inject
+//! table-length columns and rows into a [`Table`].
+//! 
+//! ---
+//! 
+//! * [`Panel`] supports four injection options:
+//!     * Horizontal | manual index selection
+//!     * Vertical | manual index selection
+//!     * Header | before first row
+//!     * Footer | after last row
 
 use tabled::{
     settings::{

--- a/tabled/examples/panel.rs
+++ b/tabled/examples/panel.rs
@@ -4,9 +4,9 @@
 //!
 //! This example demonstrates using the [`Panel`] [`TableOption`] to inject
 //! table-length columns and rows into a [`Table`].
-//! 
+//!
 //! ---
-//! 
+//!
 //! * [`Panel`] supports four injection options:
 //!     * Horizontal | manual index selection
 //!     * Vertical | manual index selection

--- a/tabled/examples/rotate.rs
+++ b/tabled/examples/rotate.rs
@@ -4,9 +4,9 @@
 //!
 //! This example demonstrates using the [`Rotate`] [`TableOption`] to rotate the cells
 //! of a [`Table`].
-//! 
+//!
 //! ---
-//! 
+//!
 //! * [`Rotate`] supports four motions:
 //!     * `Left` | 90 degree shift
 //!     * `Right` | 90 degree shift

--- a/tabled/examples/rotate.rs
+++ b/tabled/examples/rotate.rs
@@ -1,5 +1,16 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example rotate`
+//!
+//! This example demonstrates using the [`Rotate`] [`TableOption`] to rotate the cells
+//! of a [`Table`].
+//! 
+//! ---
+//! 
+//! * [`Rotate`] supports four motions:
+//!     * `Left` | 90 degree shift
+//!     * `Right` | 90 degree shift
+//!     * `Top` & `Bottom` | Reverse row order
 
 use tabled::{settings::Rotate, Table, Tabled};
 

--- a/tabled/examples/settings_list.rs
+++ b/tabled/examples/settings_list.rs
@@ -1,5 +1,14 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example settings_list`
+//!
+//! This example demonstrates using the [`Settings`] [`TableOption`] to array
+//! [`Table`] configurations in a separate step from instantiation.
+//!
+//! ---
+//!
+//! * Note how this methodoly can lead to huge performance gains
+//! with compile-time constants.
 
 use tabled::{
     settings::{

--- a/tabled/examples/shadow.rs
+++ b/tabled/examples/shadow.rs
@@ -1,20 +1,20 @@
-//! The example relays on STDIN to read the message which will be outputted.
+//! This example can be run with the following command:
 //!
-//! The table is inspired by <https://en.wikipedia.org/wiki/Box-drawing_character>
+//! `echo -e -n 'Some text\nIn the box' | cargo run --example shadow`
 //!
+//! This example demonstrates using the [`Shadow`] [`TableOption`] to create
+//! a striking frame around a [`Table`] display.
 //!
-//! ┌───────────────────┐
-//! │  ╔═══╗ Some Text  │▒
-//! │  ╚═╦═╝ in the box │▒
-//! ╞═╤══╩══╤═══════════╡▒
-//! │ ├──┬──┤           │▒
-//! │ └──┴──┘           │▒
-//! └───────────────────┘▒
-//!  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+//! ---
 //!
-//! ## Example
+//! * [`Shadow`] supports several configurations:
+//!     * Thickness
+//!     * Offset
+//!     * Direction
+//!     * Color
+//!     * Fill character
 //!
-//! `echo -e -n 'Some text\nIn the box' | cargo run --package tabled --example shadow`
+//! * 🎉 Inspired by <https://en.wikipedia.org/wiki/Box-drawing_character>
 
 use std::{io::Read, iter::FromIterator};
 

--- a/tabled/examples/span.rs
+++ b/tabled/examples/span.rs
@@ -1,5 +1,18 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example span`
+//!
+//! This example demonstrates using the [`Span`] [`CellOption`] to
+//! extend [Cells](Cell) over a specified number of columns/rows.
+//!
+//! ---
+//! 
+//! * Note how [`Span`] is available for [`Cell`] modifications
+//! after the [`Modify`] [`TableOption`] is applied. 
+//! 
+//! * ⚠️ `with()` is a reused pattern within [`tabled`] for both [`Table`]
+//! and [`Cell`] modifications. It can be easy for beginners to mistakenly 
+//! try to pass [`settings`] intended for one to the other.
 
 use tabled::{
     settings::{

--- a/tabled/examples/span.rs
+++ b/tabled/examples/span.rs
@@ -6,12 +6,12 @@
 //! extend [Cells](Cell) over a specified number of columns/rows.
 //!
 //! ---
-//! 
+//!
 //! * Note how [`Span`] is available for [`Cell`] modifications
-//! after the [`Modify`] [`TableOption`] is applied. 
-//! 
+//! after the [`Modify`] [`TableOption`] is applied.
+//!
 //! * ⚠️ `with()` is a reused pattern within [`tabled`] for both [`Table`]
-//! and [`Cell`] modifications. It can be easy for beginners to mistakenly 
+//! and [`Cell`] modifications. It can be easy for beginners to mistakenly
 //! try to pass [`settings`] intended for one to the other.
 
 use tabled::{

--- a/tabled/examples/split.rs
+++ b/tabled/examples/split.rs
@@ -1,5 +1,17 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example split`
+//!
+//! This example demonstrates using the [`Split`] [`TableOption`] to
+//! transform a [`Table`] display in multiple ways.
+//!
+//! ---
+//!
+//! * Several configurations are available to customize a [`Split`] instruction:
+//!     * [`Index`](usize)
+//!     * [`Behavior`]
+//!     * [`Direction`]
+//!     * [`Display`]
 
 use std::iter::FromIterator;
 use tabled::{

--- a/tabled/examples/table.rs
+++ b/tabled/examples/table.rs
@@ -1,5 +1,28 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example table`
+//!
+//! This example demonstrates the fundemental qualities of the [crate](https://crates.io/crates/tabled) [`tabled`].
+//!
+//! ---
+//!
+//! * [`tabled`] is powered by convenient [procedural macros](https://doc.rust-lang.org/reference/procedural-macros.html#procedural-macros)
+//! like [`Tabled`]; a deriveable trait that allows your custom
+//! structs and enums to be represented with [`tabled`]'s powerful suite of features.
+//!
+//! * [`Table`] is the root object to which all of [`tabled`]'s implementation
+//! tools guide you, and from which all of its customization options derive value.
+//! The READMEs, examples, and docs found in this project will show you many dozens
+//! of ways you can build tables, and show you how to use the available tools
+//! to build the data representations that best fit your needs.
+//! 
+//! * [`Table::with()`] plays a central role in giving the user control over their 
+//! displays. A majority of [`Table`] customizations are implemented through this highly
+//! dynamic function. A few [`TableOptions`](TableOption) include:
+//!     * [`Style`]
+//!     * [`Modify`]
+//!     * [`Alignment`]
+//!     * [`Padding`]
 
 use tabled::{
     settings::{object::Rows, Alignment, Modify, Style},

--- a/tabled/examples/table.rs
+++ b/tabled/examples/table.rs
@@ -15,8 +15,8 @@
 //! The READMEs, examples, and docs found in this project will show you many dozens
 //! of ways you can build tables, and show you how to use the available tools
 //! to build the data representations that best fit your needs.
-//! 
-//! * [`Table::with()`] plays a central role in giving the user control over their 
+//!
+//! * [`Table::with()`] plays a central role in giving the user control over their
 //! displays. A majority of [`Table`] customizations are implemented through this highly
 //! dynamic function. A few [`TableOptions`](TableOption) include:
 //!     * [`Style`]

--- a/tabled/examples/table_width.rs
+++ b/tabled/examples/table_width.rs
@@ -1,5 +1,17 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example table_width`
+//!
+//! This example demonstrates using the [`Width`] [`TableOption`] to expand and
+//! contract a [`Table`] display.
+//!
+//! ---
+//!
+//! * Note how table-wide size adjustments are applied proportionally to all columns.
+//!
+//! * Note how [fluent](https://en.wikipedia.org/wiki/Fluent_interface) functions
+//! are available to make subtle customizations to [`Width`] primary features like
+//! [`Width::truncate()`], [`Width::increase()`], and [`Width::wrap()`].
 
 use tabled::{
     settings::{measurement::Percent, object::Segment, Alignment, Modify, Style, Width},

--- a/tabled/examples/table_width_2.rs
+++ b/tabled/examples/table_width_2.rs
@@ -1,5 +1,11 @@
-//! The example can be run by this command
+//! This example can be run with the following command:
+//!
 //! `cargo run --example table_width_2`
+//!
+//! This example demonstrates using [`Wrap::keep_words()`] to preserve
+//! word shape while truncating a table to the specified size. Without
+//! this setting enabled, a word could possibly be split into pieces,
+//! greatly reducing the legibility of the display.
 
 use tabled::{
     settings::{object::Segment, Alignment, Modify, Style, Width},

--- a/tabled/src/tables/extended.rs
+++ b/tabled/src/tables/extended.rs
@@ -56,7 +56,7 @@ use crate::Tabled;
 /// `ExtendedTable` display data in a 'expanded display mode' from postgresql.
 /// It may be useful for a large data sets with a lot of fields.
 ///
-/// See 'Examples' in <https://www.postgresql.org/docs/current/app-psql.html.>.
+/// See 'Examples' in <https://www.postgresql.org/docs/current/app-psql.html>.
 ///
 /// It escapes strings to resolve a multi-line ones.
 /// Because of that ANSI sequences will be not be rendered too so colores will not be showed.


### PR DESCRIPTION
# Addressing #296

I've updated a handful of the examples, and would love some feedback before I proceed with the rest. I'm _attempting_ to keep the descriptions brief while identifying all the major ideas of each example and providing links where appropriate to further contextualize libraries referenced.

# Progress

- [X] csv_to_table
- [X] json_to_table
- [x] papergrid
- [x] static_table
- [x] table_to_html
- [x] tabled
    - [X] derive
- [X] tabled_derive

# Omitted [^1]

 - use_in_docs `static_table`
 - show `tabled`
 - terminal_size `tabled`

# Criticism Welcome 😄 
If you have any preferences whatsoever, please let me know and I will change what we've got so far. Or if you'd rather leave the examples as-is that's good too 👍🏻 

[^1]: tests not `cargo run --example` accessible