### PR TITLE
fix(macro hygiene): use the absolute path in Tabled derive macro

### DIFF
--- a/tabled/tests/derive_test.rs
+++ b/tabled/tests/derive_test.rs
@@ -1080,3 +1080,11 @@ fn test_skip_enum_0() {
     assert_eq!(Letters::Consonant('c').fields(), vec!["", "+"]);
     assert_eq!(Letters::Digit.fields(), vec!["", ""]);
 }
+
+mod __ {
+    #[test]
+    fn dont_import_the_trait() {
+        #[derive(tabled::Tabled)]
+        struct __;
+    }
+}

--- a/tabled_derive/src/lib.rs
+++ b/tabled_derive/src/lib.rs
@@ -45,7 +45,7 @@ fn impl_tabled(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let expanded = quote! {
-        impl #impl_generics Tabled for #name #ty_generics #where_clause {
+        impl #impl_generics ::tabled::Tabled for #name #ty_generics #where_clause {
             const LENGTH: usize = #length;
 
             fn fields(&self) -> Vec<::std::borrow::Cow<'_, str>> {


### PR DESCRIPTION
and the caller doesn't need to import Tabled trait