### PR TITLE
Typo: on lib.rs docs comment from "almoust" to "almost"

### DIFF
--- a/tabled/src/lib.rs
+++ b/tabled/src/lib.rs
@@ -69,7 +69,7 @@
 //! ```
 //!
 //! Because `tabled` must know what we're up to print as a field, so
-//! each (almoust) field must implement [`std::fmt::Display`].
+//! each (almost) field must implement [`std::fmt::Display`].
 //!
 //! ### Default implementations
 //!


### PR DESCRIPTION
I'm using tabled on my project, and if I find any other typos, I'd be happy to fix them in the same pull request if it's not yet merged.
In the meantime, if someone has found another typo(or documentation fix) then this PR can be used for the same.

Thank you

