### PR TITLE
Fix for cargo clippy

### DIFF
--- a/json_to_table/src/table/collapsed_table.rs
+++ b/json_to_table/src/table/collapsed_table.rs
@@ -585,6 +585,7 @@ fn generate_value_cell(value: &str, cfg: &Config, ctx: PrintContext) -> CellData
     CellData::new(table, vec![ctx.size.width], vec![ctx.size.height])
 }
 
+#[allow(dead_code)]
 struct NoTopBorders;
 
 impl<R, D> TableOption<R, ColoredConfig, D> for NoTopBorders {
@@ -627,6 +628,7 @@ impl<R, D> TableOption<R, ColoredConfig, D> for NoRightBorders {
     }
 }
 
+#[allow(dead_code)]
 struct NoLeftBorders;
 
 impl<R, D> TableOption<R, ColoredConfig, D> for NoLeftBorders {
@@ -685,6 +687,7 @@ impl<R, D> TableOption<R, ColoredConfig, D> for TopRightChangeToRight {
     }
 }
 
+#[allow(dead_code)]
 struct BottomLeftChangeSplit;
 
 impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeSplit {
@@ -696,6 +699,7 @@ impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeSplit {
     }
 }
 
+#[allow(dead_code)]
 struct BottomLeftChangeSplitToIntersection;
 
 impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeSplitToIntersection {
@@ -707,6 +711,7 @@ impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeSplitToIntersect
     }
 }
 
+#[allow(dead_code)]
 struct BottomRightChangeToRight;
 
 impl<R, D> TableOption<R, ColoredConfig, D> for BottomRightChangeToRight {
@@ -729,6 +734,7 @@ impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeToBottomIntersec
     }
 }
 
+#[allow(dead_code)]
 struct SetBottomChars<'a>(&'a [usize], char);
 
 impl<R, D> TableOption<R, ColoredConfig, D> for SetBottomChars<'_>

--- a/papergrid/src/config/spanned/mod.rs
+++ b/papergrid/src/config/spanned/mod.rs
@@ -282,7 +282,7 @@ impl SpannedConfig {
     /// It takes not cell position but line as row and column of a cell;
     /// So its range is line <= count_rows && col < count_columns.
     pub fn is_overridden_horizontal(&self, pos: Position) -> bool {
-        self.horizontal_chars.get(&pos).is_some()
+        self.horizontal_chars.contains_key(&pos)
     }
 
     /// Removes a list of overridden chars in a horizontal border.
@@ -336,7 +336,7 @@ impl SpannedConfig {
     /// It takes not cell position but cell row and column of a line;
     /// So its range is row < count_rows && col <= count_columns.
     pub fn is_overridden_vertical(&self, pos: Position) -> bool {
-        self.vertical_chars.get(&pos).is_some()
+        self.vertical_chars.contains_key(&pos)
     }
 
     /// Removes a list of overridden chars in a horizontal border.

--- a/tabled/src/settings/merge/mod.rs
+++ b/tabled/src/settings/merge/mod.rs
@@ -38,6 +38,9 @@ impl<R, D> TableOption<R, ColoredConfig, D> for MergeDuplicatesVertical
 where
     R: Records + PeekableRecords + ExactRecords,
 {
+    #[allow(clippy::assigning_clones)]
+    // NOTE: Temporarily disabled due to a issue with `assigning_clones` not respecting MSRV in clippy 1.78.0.
+    //       See https://github.com/rust-lang/rust-clippy/issues/12502
     fn change(self, records: &mut R, cfg: &mut ColoredConfig, _: &mut D) {
         let count_rows = records.count_rows();
         let count_cols = records.count_columns();
@@ -122,6 +125,9 @@ impl<R, D> TableOption<R, ColoredConfig, D> for MergeDuplicatesHorizontal
 where
     R: Records + PeekableRecords + ExactRecords,
 {
+    #[allow(clippy::assigning_clones)]
+    // NOTE: Temporarily disabled due to a issue with `assigning_clones` not respecting MSRV in clippy 1.78.0.
+    //       See https://github.com/rust-lang/rust-clippy/issues/12502
     fn change(self, records: &mut R, cfg: &mut ColoredConfig, _: &mut D) {
         let count_rows = records.count_rows();
         let count_cols = records.count_columns();

--- a/tabled/src/settings/width/truncate.rs
+++ b/tabled/src/settings/width/truncate.rs
@@ -371,7 +371,7 @@ where
 
     for ((row, col), width) in points {
         let mut truncate = Truncate::new(width);
-        truncate.suffix = suffix.clone();
+        truncate.suffix.clone_from(&suffix);
         truncate.multiline = multiline;
         CellOption::change(truncate, records, cfg, (row, col).into());
     }

--- a/tabled/src/tables/table_pool.rs
+++ b/tabled/src/tables/table_pool.rs
@@ -984,6 +984,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct ConfigCell(PrintContext);
 
     impl<R, D> TableOption<R, ColoredConfig, D> for ConfigCell {
@@ -1097,6 +1098,7 @@ mod print {
         borders.vertical = None;
     }
 
+    #[allow(dead_code)]
     fn cfg_set_top_chars(cfg: &mut ColoredConfig, list: &[usize], c: char) {
         for &split in list {
             let offset = split;
@@ -1104,12 +1106,14 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     fn cfg_set_left_chars(cfg: &mut ColoredConfig, list: &[usize], c: char) {
         for &offset in list {
             cfg.set_vertical_char((0, 0), c, Offset::Begin(offset));
         }
     }
 
+    #[allow(dead_code)]
     struct NoTopBorders;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for NoTopBorders {
@@ -1124,6 +1128,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct NoBottomBorders;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for NoBottomBorders {
@@ -1138,6 +1143,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct NoRightBorders;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for NoRightBorders {
@@ -1152,6 +1158,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct NoLeftBorders;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for NoLeftBorders {
@@ -1166,6 +1173,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct TopLeftChangeTopIntersection;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for TopLeftChangeTopIntersection {
@@ -1177,6 +1185,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct TopLeftChangeIntersection;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for TopLeftChangeIntersection {
@@ -1188,6 +1197,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct TopLeftChangeToLeft;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for TopLeftChangeToLeft {
@@ -1199,6 +1209,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct TopRightChangeToRight;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for TopRightChangeToRight {
@@ -1210,6 +1221,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct BottomLeftChangeSplit;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeSplit {
@@ -1221,6 +1233,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct BottomLeftChangeSplitToIntersection;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeSplitToIntersection {
@@ -1232,6 +1245,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct BottomRightChangeToRight;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for BottomRightChangeToRight {
@@ -1243,6 +1257,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct BottomLeftChangeToBottomIntersection;
 
     impl<R, D> TableOption<R, ColoredConfig, D> for BottomLeftChangeToBottomIntersection {
@@ -1254,6 +1269,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct SetBottomChars<'a>(&'a [usize], char);
 
     impl<R, D> TableOption<R, ColoredConfig, D> for SetBottomChars<'_>
@@ -1285,6 +1301,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct SetTopChars<'a>(&'a [usize], char);
 
     impl<R, D> TableOption<R, ColoredConfig, D> for SetTopChars<'_> {
@@ -1296,6 +1313,7 @@ mod print {
         }
     }
 
+    #[allow(dead_code)]
     struct SetLeftChars<'a>(&'a [usize], char);
 
     impl<R, D> TableOption<R, ColoredConfig, D> for SetLeftChars<'_> {
@@ -1614,6 +1632,7 @@ mod print {
         )
     }
 
+    #[allow(dead_code)]
     fn cfg_clear_borders(cfg: &mut ColoredConfig) {
         cfg.remove_borders();
         cfg.remove_borders_colors();


### PR DESCRIPTION
This PR fixes the issue of clippy failing in CI.

As noted in the comments, I've temporarily disabled `assiginig_clones` due to a bug in which clippy does not respect the version of rust. (`assiginig_clones` is actually available since rust 1.63.0. Currently the [`rust-version` in `Cargo.toml` is 1.61.0](https://github.com/zhiburt/tabled/blob/f454b5ab6efd2f2a6b3c3a416098d4fd1347315d/tabled/Cargo.toml#L14).)

ref: https://github.com/rust-lang/rust-clippy/issues/12502

