### PR TITLE
fix: do not apply `derive` on `type Position`

### DIFF
--- a/papergrid/src/config/position.rs
+++ b/papergrid/src/config/position.rs
@@ -10,5 +10,4 @@
 /// │ 1 │ 2 │
 /// └───┴───┘
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub type Position = (usize, usize);


### PR DESCRIPTION
https://github.com/zhiburt/tabled/pull/406#issuecomment-2176038543