### PR TITLE
fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added more features to `themes::Theme`.
 - Added a new setting `Reverse` to reverse the table.
 - Added vertical support for `LineText`.
-- Added `ByContet` locator.
+- Added `ByContent` locator.
 - Added `ByCondition` locator.
 - Added `Locator` factory for `Location`s.
 - Added tabled features to all subprojects to be able to reduce binary size.

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ The style will look like the following.
 #### Cell Border
 
 Sometimes `tabled::Style` settings are not enough.
-Sometimes it's nesessary to change a border of a particular cell.
+Sometimes it's necessary to change a border of a particular cell.
 
 For this purpose you can use `Border`.
 

--- a/papergrid/src/config/spanned/borders_config.rs
+++ b/papergrid/src/config/spanned/borders_config.rs
@@ -262,12 +262,12 @@ impl<T> BordersConfig<T> {
         let use_left = pos.1 == 0;
         let use_right = pos.1 == count_cols;
 
-        let itersection = self.cells.intersection.get(&pos);
-        if itersection.is_some() {
-            return itersection;
+        let intersection = self.cells.intersection.get(&pos);
+        if intersection.is_some() {
+            return intersection;
         }
 
-        let itersection = self.horizontals.get(&pos.0).and_then(|l| {
+        let intersection = self.horizontals.get(&pos.0).and_then(|l| {
             if use_left && l.left.is_some() {
                 l.left.as_ref()
             } else if use_right && l.right.is_some() {
@@ -278,11 +278,11 @@ impl<T> BordersConfig<T> {
                 None
             }
         });
-        if itersection.is_some() {
-            return itersection;
+        if intersection.is_some() {
+            return intersection;
         }
 
-        let itersection = self.verticals.get(&pos.1).and_then(|l| {
+        let intersection = self.verticals.get(&pos.1).and_then(|l| {
             if use_top && l.top.is_some() {
                 l.top.as_ref()
             } else if use_bottom && l.bottom.is_some() {
@@ -293,11 +293,11 @@ impl<T> BordersConfig<T> {
                 None
             }
         });
-        if itersection.is_some() {
-            return itersection;
+        if intersection.is_some() {
+            return intersection;
         }
 
-        let itersection = {
+        let intersection = {
             if use_top && use_left {
                 self.borders.top_left.as_ref()
             } else if use_top && use_right {
@@ -318,8 +318,8 @@ impl<T> BordersConfig<T> {
                 self.borders.intersection.as_ref()
             }
         };
-        if itersection.is_some() {
-            return itersection;
+        if intersection.is_some() {
+            return intersection;
         }
 
         self.global.as_ref()

--- a/static_table/README.md
+++ b/static_table/README.md
@@ -29,7 +29,6 @@ An example of `static_table` usage.
 <tr>
 <td>
 
-
 ```rust
 use static_table::static_table;
 
@@ -134,7 +133,7 @@ pub fn add(left: usize, right: usize) -> usize {
 ## Binary size concern
 
 It's something you shall be aware of.
-Using `static_table` MIGHT increase a binary size, because the table will be stored as actuall symbols in a static section of a binary file (ELF, PE etc.).
+Using `static_table` MIGHT increase a binary size, because the table will be stored as actual symbols in a static section of a binary file (ELF, PE etc.).
 
 I have run a few tests in this regard.
 And a binary which used `static_table` has SUBSTATIANALY smaller size than

--- a/tabled/benches/lib_comp/README.md
+++ b/tabled/benches/lib_comp/README.md
@@ -1,8 +1,8 @@
 # Benchmark's
 
-We profile only actuall table construction.
+We profile only actual table construction.
 
-**Be WARE** that it's being run agains a specific (but general) use case.
+**Be WARE** that it's being run against a specific (but general) use case.
 Some libraries **might** perform better in certain scenarios or certain use cases.
 
 ## Result

--- a/tabled/examples/derive/format.rs
+++ b/tabled/examples/derive/format.rs
@@ -1,5 +1,5 @@
 //! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
-//! [`format`] to beatifuly castomize the resulting values, be used for table constraction.
+//! [`format`] to beatifuly castomize the resulting values, be used for table contraction.
 
 use tabled::{settings::Style, Table, Tabled};
 

--- a/tabled/src/grid/records/mod.rs
+++ b/tabled/src/grid/records/mod.rs
@@ -1,7 +1,7 @@
 //! The module contains [`Records`], [`ExactRecords`], [`RecordsMut`], [`Resizable`] traits
 //! and its implementations.
 //!
-//! Also it provies a list of helpers for a user built [`Records`] via [`into_records`].
+//! Also it provides a list of helpers for a user built [`Records`] via [`into_records`].
 
 mod empty_records;
 mod records_mut;

--- a/tabled/src/lib.rs
+++ b/tabled/src/lib.rs
@@ -430,7 +430,7 @@ pub use crate::{tabled::Tabled, tables::Table};
 /// }
 /// ```
 ///
-/// There's also a probably more sutable way for formatting, if your format is contant.
+/// There's also a probably more suitable way for formatting, if your format is constant.
 /// Using `#[tabled(format = "{}")]` and `#[tabled(format("{}"))]` and proving a general formatting string.
 ///
 /// ```

--- a/tabled/src/settings/height/cell_height_increase.rs
+++ b/tabled/src/settings/height/cell_height_increase.rs
@@ -29,7 +29,7 @@ impl<W> CellHeightIncrease<W> {
         Self { height }
     }
 
-    /// The priority makes scence only for table, so the function
+    /// The priority makes sense only for table, so the function
     /// converts it to [`TableHeightIncrease`] with a given priority.
     pub fn priority<P>(self) -> TableHeightIncrease<W, P>
     where

--- a/tabled/src/settings/style/border_text.rs
+++ b/tabled/src/settings/style/border_text.rs
@@ -293,7 +293,7 @@ fn set_vertical_chars<D>(
                     None => return,
                 };
 
-                cfg.set_vertical_char((row, line), c, config::Offset::Begin(off)); // todo: is this correct? I thik it shall be off + i
+                cfg.set_vertical_char((row, line), c, config::Offset::Begin(off)); // todo: is this correct? I think it shall be off + i
 
                 if let Some(color) = color.as_ref() {
                     cfg.set_vertical_color((row, line), color.clone(), config::Offset::Begin(off));

--- a/tabled/src/settings/themes/mod.rs
+++ b/tabled/src/settings/themes/mod.rs
@@ -1,4 +1,4 @@
-//! The module contains a varieity of configurations of table, which often
+//! The module contains a variety of configurations of table, which often
 //! changes not a single setting.
 //! As such they are making relatively big changes to the configuration.
 

--- a/tabled/src/settings/width/min_width.rs
+++ b/tabled/src/settings/width/min_width.rs
@@ -78,7 +78,7 @@ impl<W, P> MinWidth<W, P> {
     /// Set's a fill character which will be used to fill the space
     /// when increasing the length of the string to the set boundary.
     ///
-    /// Used only if chaning cells.
+    /// Used only if changing cells.
     pub fn fill_with(mut self, c: char) -> Self {
         self.fill = c;
         self

--- a/tabled/src/settings/width/truncate.rs
+++ b/tabled/src/settings/width/truncate.rs
@@ -198,8 +198,8 @@ where
         let mut suffix = Cow::Borrowed("");
 
         if let Some(x) = self.suffix.as_ref() {
-            let (cutted_suffix, rest_width) = make_suffix(x, width);
-            suffix = cutted_suffix;
+            let (cut_suffix, rest_width) = make_suffix(x, width);
+            suffix = cut_suffix;
             width = rest_width;
         };
 

--- a/tabled/src/settings/width/wrap.rs
+++ b/tabled/src/settings/width/wrap.rs
@@ -1431,7 +1431,7 @@ mod tests {
                 "\u{1b}[37m(l\u{1b}[39m\u{1b}[37m\u{1b}[41marg\u{1b}[39m\u{1b}[49m\u{1b}[37mest \u{1b}[39m \n",
                 "\u{1b}[37minteger \u{1b}[39m  \n",
                 "\u{1b}[37mless than \u{1b}[39m\n",
-                "\u{1b}[37more equal \u{1b}[39m \n",
+                "\u{1b}[37mor equal \u{1b}[39m \n",
                 "\u{1b}[37mto that \u{1b}[39m  \n",
                 "\u{1b}[37mnumber).\u{1b}[39m  ",
             )
@@ -1446,7 +1446,7 @@ mod tests {
 //  \u{1b}[37m\u{1b}[41m(l\u{1b}[39m\u{1b}[37m\u{1b}[41marg\u{1b}[39m\u{1b}[49m\u{1b}[37mest \u{1b}[39m\n
 //  \u{1b}[37minteger \u{1b}[39m\n
 //  \u{1b}[37mless than \u{1b}[39m\n
-//  \u{1b}[37more equal \u{1b}[39m\n
+//  \u{1b}[37mor equal \u{1b}[39m\n
 //  \u{1b}[37mto that \u{1b}[39m\n
 //  \u{1b}[37mnumber).\u{1b}[39m  "
 
@@ -1460,7 +1460,7 @@ mod tests {
 //  \u{1b}[37m\u{1b}[41m(l\u{1b}[39m\u{1b}[37m\u{1b}[41marg\u{1b}[39m\u{1b}[49m\u{1b}[37mest \u{1b}[39m\n
 //  \u{1b}[37minteger \u{1b}[39m\n
 //  \u{1b}[37mless than \u{1b}[39m\n
-//  \u{1b}[37more equal \u{1b}[39m\n
+//  \u{1b}[37mor equal \u{1b}[39m\n
 //  \u{1b}[37mto that \u{1b}[39m\n
 //  \u{1b}[37mnumber).\u{1b}[39m  "
 
@@ -1471,6 +1471,6 @@ mod tests {
 // \u{1b}[37m\u{1b}[41m(l\u{1b}[39m\u{1b}[37m\u{1b}[41marg\u{1b}[39m\u{1b}[49m\u{1b}[37mest\u{1b}[37m \u{1b}[39m\n
 // \u{1b}[37minteger\u{1b}[37m \u{1b}[39m\n
 // \u{1b}[37mless\u{1b}[37m than\u{1b}[37m \u{1b}[39m\n
-// \u{1b}[37more\u{1b}[37m equal\u{1b}[37m \u{1b}[39m\n
+// \u{1b}[37mor\u{1b}[37m equal\u{1b}[37m \u{1b}[39m\n
 // \u{1b}[37mto\u{1b}[37m that\u{1b}[37m \u{1b}[39m\n
 // \u{1b}[37mnumber).\u{1b}[39m  "


### PR DESCRIPTION
- fix new typos
- revert typos fixes (`\u{1b}[37mor`)