### PR TITLE
fix(deps): migrate from proc-macro-error to proc-macro-error2

### DIFF
--- a/static_table/Cargo.toml
+++ b/static_table/Cargo.toml
@@ -24,7 +24,7 @@ tabled = { version = "0.16", features = ["std"], default-features = false }
 syn = { version = "1", features = ["parsing"] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-error = "1.0"
+proc-macro-error2 = "2.0.1"
 
 [dev-dependencies]
 testing_table = { version = "0.1", features = ["ansi"] }

--- a/static_table/src/lib.rs
+++ b/static_table/src/lib.rs
@@ -167,7 +167,7 @@
     html_logo_url = "https://raw.githubusercontent.com/zhiburt/tabled/86ac146e532ce9f7626608d7fd05072123603a2e/assets/tabled-gear.svg"
 )]
 
-use proc_macro_error::proc_macro_error;
+use proc_macro_error2::proc_macro_error;
 use quote::quote;
 use syn::parse_macro_input;
 

--- a/static_table/src/pool_table.rs
+++ b/static_table/src/pool_table.rs
@@ -313,7 +313,7 @@ fn build_margin(pad: Pad<LitInt>) -> syn::Result<Margin> {
 }
 
 fn panic_not_supported_theme(ident: &LitStr) {
-    proc_macro_error::abort!(
+    proc_macro_error2::abort!(
         ident,
         "The given settings is not supported";
         note="custom themes are yet not supported";
@@ -322,7 +322,7 @@ fn panic_not_supported_theme(ident: &LitStr) {
 }
 
 fn panic_not_supported_alignment(ident: &LitStr) {
-    proc_macro_error::abort!(
+    proc_macro_error2::abort!(
         ident,
         "The given settings is not supported";
         note="custom themes are yet not supported";
@@ -331,7 +331,7 @@ fn panic_not_supported_alignment(ident: &LitStr) {
 }
 
 fn panic_not_supported_settings(ident: &Ident) {
-    proc_macro_error::abort!(
+    proc_macro_error2::abort!(
         ident,
         "The given settings is not supported";
         help = r#"Supported list is [THEME, PADDING, MARGIN]"#

--- a/static_table/src/static_table.rs
+++ b/static_table/src/static_table.rs
@@ -588,7 +588,7 @@ fn build_margin(pad: Pad<LitInt>) -> syn::Result<Margin> {
 }
 
 fn panic_not_supported_theme(ident: &LitStr) {
-    proc_macro_error::abort!(
+    proc_macro_error2::abort!(
         ident,
         "The given settings is not supported";
         note="custom themes are yet not supported";
@@ -597,7 +597,7 @@ fn panic_not_supported_theme(ident: &LitStr) {
 }
 
 fn panic_not_supported_alignment(ident: &LitStr) {
-    proc_macro_error::abort!(
+    proc_macro_error2::abort!(
         ident,
         "The given settings is not supported";
         help = r#"Supported alignment are [LEFT, RIGHT, CENTER, CENTER_VERTICAL, TOP, BOTTOM]"#
@@ -606,7 +606,7 @@ fn panic_not_supported_alignment(ident: &LitStr) {
 
 #[allow(dead_code)]
 fn panic_not_supported_bool(ident: &LitStr) {
-    proc_macro_error::abort!(
+    proc_macro_error2::abort!(
         ident,
         "Unexpected bool value";
         help = r#"Expected to get [TRUE, FALSE]"#
@@ -614,7 +614,7 @@ fn panic_not_supported_bool(ident: &LitStr) {
 }
 
 fn panic_not_supported_settings(ident: &Ident) {
-    proc_macro_error::abort!(
+    proc_macro_error2::abort!(
         ident,
         "The given settings is not supported";
         help = r#"Supported list is [THEME, PADDING, MARGIN]"#

--- a/tabled_derive/Cargo.toml
+++ b/tabled_derive/Cargo.toml
@@ -15,4 +15,4 @@ syn = { version = "1", features = ["full", "visit-mut"] }
 quote = "1"
 proc-macro2 = "1"
 heck = "0.4"
-proc-macro-error = "1.0"
+proc-macro-error2 = "2.0.1"

--- a/tabled_derive/src/error.rs
+++ b/tabled_derive/src/error.rs
@@ -55,14 +55,14 @@ impl std::error::Error for Error {}
 pub fn abort(err: Error) -> ! {
     match err {
         Error::Syn(err) => {
-            proc_macro_error::abort! {err.span(), "{}", err}
+            proc_macro_error2::abort! {err.span(), "{}", err}
         }
         Error::Custom { span, error, help } => match help {
             Some(help) => {
-                proc_macro_error::abort! {span, "{}",  error; help="{}", help}
+                proc_macro_error2::abort! {span, "{}",  error; help="{}", help}
             }
             None => {
-                proc_macro_error::abort! {span, "{}",  error}
+                proc_macro_error2::abort! {span, "{}",  error}
             }
         },
     }

--- a/tabled_derive/src/lib.rs
+++ b/tabled_derive/src/lib.rs
@@ -12,7 +12,7 @@ mod parse;
 
 use attributes::FormatArg;
 use proc_macro2::TokenStream;
-use proc_macro_error::proc_macro_error;
+use proc_macro_error2::proc_macro_error;
 use quote::{quote, ToTokens, TokenStreamExt};
 use std::{collections::HashMap, str};
 use syn::visit_mut::VisitMut;


### PR DESCRIPTION
# Migrate from proc-macro-error to proc-macro-error2

## Overview

Replaces the `proc-macro-error` crate with [`proc-macro-error2`](https://github.com/GnomedDev/proc-macro-error-2), an actively maintained fork.

Resolves #425.

## Changes

- Replace `proc-macro-error` with the latest version of `proc-macro-error2` in `Cargo.toml`
- Replace `proc-macro-error` references with `proc-macro-error2`

## Motivation

The `proc-macro-error` crate has been flagged as unmaintained ([RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370)). Migrating to `proc-macro-error2` addresses this security advisory and ensures our project uses an actively maintained dependency.

## Testing

- [X] All existing tests have been updated and pass