### PR TITLE
Fix a comment to make doctests happy

### DIFF
--- a/tabled/src/settings/cell_option.rs
+++ b/tabled/src/settings/cell_option.rs
@@ -5,7 +5,7 @@ use crate::grid::{
 
 /// A trait for configuring a single cell.
 ///
-/// ~~~~ Where cell represented by 'row' and 'column' indexes. ~~~~
+/// A cell is represented by row and column indexes.
 ///
 /// A cell can be targeted by [`Cell`].
 ///


### PR DESCRIPTION
Without this, `cargo test` says:

> warning: unexpected character `'`

Fix typos at the same time.
