### PR TITLE
Fix README.md for json_to_table

### DIFF
--- a/json_to_table/README.md
+++ b/json_to_table/README.md
@@ -196,7 +196,7 @@ fn main() {
     );
 
     let table = json_to_table(&value)
-        .set_object_mode(Orientation::Row)
+        .object_orientation(Orientation::Row)
         .to_string();
 
     println!("{}", table)


### PR DESCRIPTION
`set_object_mode` method has been renamed to `object_orientation` at #321.

https://github.com/zhiburt/tabled/blob/300c07bd53c945671e8115811c1689cb1353feff/json_to_table/src/table/mod.rs#L186-L189