### PR TITLE
Fix single_match warning

### DIFF
--- a/static_table/src/static_table.rs
+++ b/static_table/src/static_table.rs
@@ -397,20 +397,22 @@ fn collect_vspan(matrix: &MatrixInput) -> Result<HashMap<(usize, usize), usize>>
                         let arr_len = len.base10_parse::<usize>()?;
                         match elem {
                             ExprVal::Lit(_) => {}
-                            ExprVal::Scope { expr, .. } => match expr {
-                                Some(val) => match val {
-                                    ScopeVal::Expr(_) => {}
-                                    ScopeVal::List(_) => {}
-                                    ScopeVal::Sized { len, .. } => {
-                                        let len = len.base10_parse::<usize>()?;
-                                        if len > 0 {
-                                            let iter = (0..arr_len).map(|i| ((row, i * len), len));
-                                            spans.extend(iter);
+                            ExprVal::Scope { expr, .. } => {
+                                if let Some(val) = expr {
+                                    match val {
+                                        ScopeVal::Expr(_) => {}
+                                        ScopeVal::List(_) => {}
+                                        ScopeVal::Sized { len, .. } => {
+                                            let len = len.base10_parse::<usize>()?;
+                                            if len > 0 {
+                                                let iter =
+                                                    (0..arr_len).map(|i| ((row, i * len), len));
+                                                spans.extend(iter);
+                                            }
                                         }
                                     }
-                                },
-                                None => {}
-                            },
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#single_match

```
error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> static_table/src/static_table.rs:400:60
    |
400 |   ...                   ExprVal::Scope { expr, .. } => match expr {
    |  ______________________________________________________^
401 | | ...                       Some(val) => match val {
402 | | ...                           ScopeVal::Expr(_) => {}
403 | | ...                           ScopeVal::List(_) => {}
...   |
412 | | ...                       None => {}
413 | | ...                   },
    | |_______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
    = note: `-D clippy::single-match` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::single_match)]`
help: try
    |
400 ~                             ExprVal::Scope { expr, .. } => if let Some(val) = expr { match val {
401 +                                 ScopeVal::Expr(_) => {}
402 +                                 ScopeVal::List(_) => {}
403 +                                 ScopeVal::Sized { len, .. } => {
404 +                                     let len = len.base10_parse::<usize>()?;
405 +                                     if len > 0 {
406 +                                         let iter = (0..arr_len).map(|i| ((row, i * len), len));
407 +                                         spans.extend(iter);
408 +                                     }
409 +                                 }
410 ~                             } },
    |

error: could not compile `static_table` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```