### PR TITLE
Update to syn 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+- Migrated syn to 2.0 (By [@wyatt-herkamp](https://github.com/wyatt-herkamp))
 ## [0.17.0] - 2024-23-11
 
 ### Added

--- a/static_table/Cargo.toml
+++ b/static_table/Cargo.toml
@@ -21,7 +21,7 @@ macros = ["tabled/macros"]
 
 [dependencies]
 tabled = { version = "0.17", features = ["std"], default-features = false }
-syn = { version = "1", features = ["parsing"] }
+syn = { version = "2", features = ["parsing"] }
 quote = "1"
 proc-macro2 = "1"
 proc-macro-error2 = "2.0.1"

--- a/tabled_derive/Cargo.toml
+++ b/tabled_derive/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["full", "visit-mut"] }
+syn = { version = "2", features = ["full", "visit-mut"] }
 quote = "1"
 proc-macro2 = "1"
-heck = "0.4"
+heck = "0.5"
 proc-macro-error2 = "2.0.1"

--- a/tabled_derive/src/lib.rs
+++ b/tabled_derive/src/lib.rs
@@ -110,7 +110,7 @@ fn get_fields_length(fields: &Fields, tabled_trait: &ExprPath) -> Result<TokenSt
     let size_components = std::iter::once(quote!(0)).chain(size_components);
 
     let mut stream = TokenStream::new();
-    stream.append_separated(size_components, syn::token::Add::default());
+    stream.append_separated(size_components, syn::token::Plus::default());
 
     Ok(stream)
 }
@@ -123,7 +123,7 @@ fn get_enum_length(enum_ast: &DataEnum, trait_path: &ExprPath) -> Result<TokenSt
         let size = size?;
 
         if i != 0 {
-            stream.append_all(syn::token::Add::default().into_token_stream());
+            stream.append_all(syn::token::Plus::default().into_token_stream());
         }
 
         stream.append_all(size);

--- a/tabled_derive/src/parse/field_attr.rs
+++ b/tabled_derive/src/parse/field_attr.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Ident, Span};
 use syn::{
-    parenthesized, parse::Parse, punctuated::Punctuated, token, Attribute, LitBool, LitInt, LitStr,
-    Token,
+    parenthesized, parse::Parse, punctuated::Punctuated, spanned::Spanned, token, Attribute,
+    LitBool, LitInt, LitStr, Token,
 };
 
 pub fn parse_field_attributes(
@@ -9,7 +9,7 @@ pub fn parse_field_attributes(
 ) -> impl Iterator<Item = syn::Result<impl Iterator<Item = FieldAttr>>> + '_ {
     attributes
         .iter()
-        .filter(|attr| attr.path.is_ident("tabled"))
+        .filter(|attr| attr.path().is_ident("tabled"))
         .map(|attr| attr.parse_args_with(Punctuated::<FieldAttr, Token![,]>::parse_terminated))
         .map(|result| result.map(IntoIterator::into_iter))
 }
@@ -124,7 +124,7 @@ impl Parse for FieldAttr {
             }
 
             return Err(syn::Error::new(
-                _paren.span,
+                _paren.span.span(),
                 "expected a `string literal` in parenthesis",
             ));
         }

--- a/tabled_derive/src/parse/type_attr.rs
+++ b/tabled_derive/src/parse/type_attr.rs
@@ -1,6 +1,7 @@
 use proc_macro2::{Ident, Span};
 use syn::{
-    parenthesized, parse::Parse, punctuated::Punctuated, token, Attribute, LitBool, LitStr, Token,
+    parenthesized, parse::Parse, punctuated::Punctuated, spanned::Spanned, token, Attribute,
+    LitBool, LitStr, Token,
 };
 
 pub fn parse_type_attributes(
@@ -8,7 +9,7 @@ pub fn parse_type_attributes(
 ) -> impl Iterator<Item = syn::Result<impl Iterator<Item = TypeAttr>>> + '_ {
     attributes
         .iter()
-        .filter(|attr| attr.path.is_ident("tabled"))
+        .filter(|attr| attr.path().is_ident("tabled"))
         .map(|attr| attr.parse_args_with(Punctuated::<TypeAttr, Token![,]>::parse_terminated))
         .map(|result| result.map(IntoIterator::into_iter))
 }
@@ -86,7 +87,7 @@ impl Parse for TypeAttr {
             }
 
             return Err(syn::Error::new(
-                _paren.span,
+                _paren.span.span(),
                 "expected a `string literal` in parenthesis",
             ));
         }


### PR DESCRIPTION
Updates to syn 2.0

Note that the `expr_lit_to_string` function now returns an error. A CString cannot be turned into a String, without possible error. I'm not sure how you wanted this to be handled. Also, it is nonexhaustive now. 

Also closes #313