### PR TITLE
Fix clippy warnings that are breaking CI

### DIFF
--- a/tabled/src/settings/split/mod.rs
+++ b/tabled/src/settings/split/mod.rs
@@ -477,7 +477,7 @@ where
         if from_primary_index < primary_length {
             let from_position =
                 format_position(direction, from_primary_index, from_secondary_index);
-            if records.get_text(from_position) != "" {
+            if !records.get_text(from_position).is_empty() {
                 section_is_empty = false;
             }
             records.swap(

--- a/tabled/src/settings/width/truncate.rs
+++ b/tabled/src/settings/width/truncate.rs
@@ -279,7 +279,7 @@ fn need_suffix_color_preservation(_suffix: &Option<TruncateSuffix<'_>>) -> bool 
     }
     #[cfg(feature = "ansi")]
     {
-        _suffix.as_ref().map_or(false, |s| s.try_color)
+        _suffix.as_ref().is_some_and(|s| s.try_color)
     }
 }
 


### PR DESCRIPTION
- **Use `is_empty`**
- **Use `is_some_and`**
