### PR TITLE
feat: adds display_option_with type attr

### DIFF
--- a/tabled/Cargo.toml
+++ b/tabled/Cargo.toml
@@ -69,6 +69,11 @@ path = "examples/derive/display_with.rs"
 required-features = ["derive"]
 
 [[example]]
+name = "derive_display_with_option"
+path = "examples/derive/display_with_option.rs"
+required-features = ["derive"]
+
+[[example]]
 name = "derive_crate_override"
 path = "examples/derive/crate_override.rs"
 required-features = ["derive"]

--- a/tabled/examples/derive/display_with_option.rs
+++ b/tabled/examples/derive/display_with_option.rs
@@ -1,0 +1,51 @@
+use tabled::Tabled;
+
+#[derive(Debug)]
+pub struct Country {
+    name: String,
+    capital: Option<String>,
+}
+
+fn display_option(opt: &Option<String>) -> String {
+    match opt {
+        Some(val) => val.to_uppercase(),
+        None => "UNKNOWN".to_string(),
+    }
+}
+
+#[derive(Tabled)]
+#[tabled(display_option_with = "display_option")]
+pub struct CountryDisplay {
+    name: String,
+    capital: Option<String>,
+}
+
+impl From<Country> for CountryDisplay {
+    fn from(country: Country) -> Self {
+        Self {
+            name: country.name,
+            capital: country.capital,
+        }
+    }
+}
+
+fn main() {
+    let data = vec![
+        Country {
+            name: "France".to_string(),
+            capital: Some("Paris".to_string()),
+        },
+        Country {
+            name: "Germany".to_string(),
+            capital: Some("Berlin".to_string()),
+        },
+        Country {
+            name: "Unknown".to_string(),
+            capital: None,
+        },
+    ];
+
+    let table_data: Vec<CountryDisplay> = data.into_iter().map(Into::into).collect();
+    let table = tabled::Table::new(table_data);
+    println!("{}", table);
+}

--- a/tabled_derive/src/attributes/type_attr.rs
+++ b/tabled_derive/src/attributes/type_attr.rs
@@ -12,6 +12,7 @@ pub struct TypeAttributes {
     pub inline: bool,
     pub inline_value: Option<String>,
     pub crate_name: Option<String>,
+    pub display_option_with: Option<String>,
 }
 
 impl TypeAttributes {
@@ -52,6 +53,9 @@ impl TypeAttributes {
             }
             TypeAttrKind::RenameAll(lit) => {
                 self.rename_all = Some(CasingStyle::from_lit(&lit)?);
+            }
+            TypeAttrKind::DisplayOptionWith(func) => {
+                self.display_option_with = Some(func.value());
             }
         }
 

--- a/tabled_derive/src/parse/type_attr.rs
+++ b/tabled_derive/src/parse/type_attr.rs
@@ -29,6 +29,7 @@ pub enum TypeAttrKind {
     Inline(LitBool, Option<LitStr>),
     RenameAll(LitStr),
     Crate(LitStr),
+    DisplayOptionWith(LitStr),
 }
 
 impl Parse for TypeAttr {
@@ -52,8 +53,10 @@ impl Parse for TypeAttr {
             if input.peek(LitStr) {
                 let lit = input.parse::<LitStr>()?;
 
-                if let "rename_all" = name_str.as_str() {
-                    return Ok(Self::new(RenameAll(lit)));
+                match name_str.as_str() {
+                    "rename_all" => return Ok(Self::new(RenameAll(lit))),
+                    "display_option_with" => return Ok(Self::new(DisplayOptionWith(lit))),
+                    _ => {}
                 }
             }
 


### PR DESCRIPTION
I have some structs with a bunch of `Option` fields i want to put in the table

i found https://github.com/zhiburt/tabled/issues/265 but it is not ergonomic to put attr on each field, so add type-level attr