### PR TITLE
Fix `ansi` feature for `tabled` when compiling to `wasm32-unknown-unknown`

### DIFF
--- a/papergrid/Cargo.toml
+++ b/papergrid/Cargo.toml
@@ -15,9 +15,17 @@ ansi = ["ansi-str", "ansitok"]
 [dependencies]
 unicode-width = "0.2"
 bytecount = "0.6"
-ahash = { version = "0.8", optional = true }
 ansi-str = { version = "0.9", optional = true }
 ansitok = { version = "0.3", optional = true  }
+
+[dependencies.ahash]
+version = "0.8"
+optional = true
+default-features = false
+# `compile-time-rng` is necessary to allow building on wasm32,
+# we cannot use `runtime-rng` for platforms due to this known bug:
+# https://github.com/rust-lang/cargo/issues/1197
+features = ["std", "compile-time-rng"]
 
 [dev-dependencies]
 testing_table = { version = "0.2", features = ["ansi"] }

--- a/tabled/Cargo.toml
+++ b/tabled/Cargo.toml
@@ -25,7 +25,7 @@ macros = ["std"]
 assert = ["testing_table"]
 
 [dependencies]
-papergrid = { version = "0.15", default-features = false }
+papergrid = { version = "0.15", path = "../papergrid", default-features = false }
 tabled_derive = { version = "0.11", optional = true }
 testing_table = { version = "0.3", default-features = false, optional = true }
 ansi-str = { version = "0.9", optional = true }


### PR DESCRIPTION
In this PR, I swapped out the default `runtime-rng` feature of `ahash` in `papergrid` with `compile-time-rng`. This makes it possible to compile to `wasm32-unknown-unknown` without `getrandom` complaining about the missing `js` feature.

I’m not sure `runtime-rng` is even needed here. I wanted to enable it only for certain targets, but thanks to [this long-standing bug](https://github.com/rust-lang/cargo/issues/1197), that’s not possible yet.

Related: https://github.com/nushell/nushell/pull/15138

