### PR TITLE
Fix documentation references from display_with to display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1596,7 +1596,7 @@ pub struct Motorcycle {
 
 In the above example, the cc field will be formatted using the specified format string "{} cc", where {} is replaced with the value of cc.
 
-Just like with `display_with` attribute, you can pass arguments for more complex formatting scenarios:
+Just like with `display` attribute, you can pass arguments for more complex formatting scenarios:
 
 ```rust
 use tabled::Tabled;

--- a/tabled/examples/derive/display_with.rs
+++ b/tabled/examples/derive/display_with.rs
@@ -1,11 +1,11 @@
 //! This example demonstrates using the [attribute macro](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros)
-//! [`display_with`] to seamlessly augment field representations in a [`Table`] display.
+//! [`display`] to seamlessly augment field representations in a [`Table`] display.
 //!
-//! * [`display_with`] functions act as transformers during [`Table`] instantiation.
+//! * [`display`] functions act as transformers during [`Table`] instantiation.
 //!
-//! * Note how [`display_with`] works with [std] and custom functions alike.
+//! * Note how [`display`] works with [std] and custom functions alike.
 //!
-//! * [`display_with`] attributes can be constructed in two ways (shown below).
+//! * [`display`] attributes can be constructed in two ways (shown below).
 //!
 //! * Attribute arguments can be directly overridden with static values, effectively ignoring the
 //!   augmented fields natural value entirely. Even an entire object can be passed as context with `self`.


### PR DESCRIPTION
Fixes #559

The `display_with` attribute was renamed to `display` in commit 12e7276, but the documentation in `examples/derive/display_with.rs` and `README.md` still referenced the old name.