### PR TITLE
Replace needless range loop with iterator in table_builder

### DIFF
--- a/tabled/src/builder/table_builder.rs
+++ b/tabled/src/builder/table_builder.rs
@@ -537,8 +537,7 @@ fn remove_empty_rows(data: &mut Vec<Vec<Text<String>>>, count_columns: usize) {
         let row = row - deleted;
 
         let mut is_empty_row = true;
-        for col in 0..count_columns {
-            let cell = &data[row][col];
+        for cell in data[row].iter().take(count_columns) {
             if !cell.as_ref().is_empty() {
                 is_empty_row = false;
                 break;


### PR DESCRIPTION
Fixes `clippy::needless-range-loop` warning in `remove_empty_rows` function.

Replaces `for col in 0..count_columns` with `for cell in data[row].iter().take(count_columns)` since the loop variable `col` was only used for indexing.

https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop