### PR TITLE
Add Color::is_empty method

### DIFF
--- a/tabled/src/settings/color/mod.rs
+++ b/tabled/src/settings/color/mod.rs
@@ -205,6 +205,11 @@ impl Color {
         Self::new_static("", "")
     }
 
+    /// Returns true if the color has no ANSI sequences.
+    pub fn is_empty(&self) -> bool {
+        self.get_prefix().is_empty() && self.get_suffix().is_empty()
+    }
+
     /// Return a prefix.
     pub fn get_prefix(&self) -> &str {
         match &self.inner {
@@ -513,5 +518,14 @@ mod tests {
                 "\u{1b}[49m\u{1b}[39m"
             )
         )
+    }
+
+    #[test]
+    fn test_is_empty() {
+        assert!(Color::empty().is_empty());
+        assert!(!Color::FG_BLACK.is_empty());
+        assert!(!Color::BG_RED.is_empty());
+        assert!(!Color::new("a", "b").is_empty());
+        assert!(Color::new("", "").is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds `Color::is_empty()` which returns `true` when both the ANSI prefix and suffix are empty. This was a clearly missing utility method on the `Color` type.

## Changes

- `tabled/src/settings/color/mod.rs`: Added `is_empty(&self) -> bool` method and unit test covering empty, static, and dynamic color variants.

## Testing

- `cargo test -p tabled settings::color::tests::test_is_empty` passes
- `cargo clippy -- -D warnings` clean

Fixes #464

This contribution was developed with AI assistance (Claude Code).