### PR TITLE
test: add quickcheck test for wrap character preservation

### DIFF
--- a/tabled/tests/qc/tests/wrap.rs
+++ b/tabled/tests/qc/tests/wrap.rs
@@ -1,0 +1,27 @@
+use quickcheck_macros::quickcheck;
+
+use tabled::settings::width::Wrap;
+
+/// Verify that wrapping preserves all original characters (excluding newlines
+/// which are used as line separators by the wrapping algorithm).
+///
+/// Uses ASCII-only strings to avoid CJK double-width edge cases where a
+/// character wider than the wrap width must be replaced.
+#[quickcheck]
+fn qc_wrap_preserves_all_ascii_characters(bytes: Vec<u8>, width: u8) {
+    // Map bytes to printable ASCII + space (0x20..0x7E)
+    let text: String = bytes.iter().map(|b| (b % 95 + 32) as char).collect();
+    let width = (width as usize).max(1);
+
+    for keep_words in [false, true] {
+        let wrapped = Wrap::wrap(&text, width, keep_words);
+        let original_chars: Vec<char> = text.chars().filter(|c| *c != '\n').collect();
+        let wrapped_chars: Vec<char> = wrapped.chars().filter(|c| *c != '\n').collect();
+        assert_eq!(
+            original_chars, wrapped_chars,
+            "Characters lost or reordered during wrapping (width={width}, keep_words={keep_words})\n\
+             original: {text:?}\n\
+             wrapped:  {wrapped:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Added a property-based test that verifies the wrapping algorithm preserves all original characters in the output.

## Why this matters

As noted in #536, the wrapping algorithm could potentially drop characters (especially spaces) during line breaking. This quickcheck test generates random ASCII strings at random widths and asserts that every character from the input appears in the wrapped output in order.

## Changes

- `tabled/tests/qc/tests/wrap.rs`: New quickcheck test `qc_wrap_preserves_all_ascii_characters`. Generates printable ASCII strings, wraps at random widths (1+), and checks both `keep_words=true` and `keep_words=false`. Uses ASCII to avoid CJK double-width edge cases where a character wider than the wrap width is replaced.

## Testing

Test passes with `cargo test --test wrap` in the `tabled/tests/qc` directory. Quickcheck runs 100 random cases by default.

Closes #536

This contribution was developed with AI assistance (Claude Code).