### PR TITLE
feat(width): add is_ok() success indicator to Wrap and Truncate (#186)

### DIFF
--- a/tabled/src/settings/width/truncate.rs
+++ b/tabled/src/settings/width/truncate.rs
@@ -48,6 +48,7 @@ pub struct Truncate<'a, W = usize, P = PriorityNone> {
     suffix: Option<TruncateSuffix<'a>>,
     multiline: bool,
     priority: P,
+    success: bool,
 }
 
 #[cfg(feature = "ansi")]
@@ -98,6 +99,7 @@ where
             multiline: false,
             suffix: None,
             priority: PriorityNone::new(),
+            success: false,
         }
     }
 }
@@ -120,6 +122,7 @@ impl<'a, W, P> Truncate<'a, W, P> {
             multiline: self.multiline,
             priority: self.priority,
             suffix: Some(suff),
+            success: false,
         }
     }
 
@@ -133,6 +136,7 @@ impl<'a, W, P> Truncate<'a, W, P> {
             multiline: self.multiline,
             priority: self.priority,
             suffix: Some(suff),
+            success: false,
         }
     }
 
@@ -143,6 +147,7 @@ impl<'a, W, P> Truncate<'a, W, P> {
             multiline: on,
             suffix: self.suffix,
             priority: self.priority,
+            success: false,
         }
     }
 
@@ -157,6 +162,7 @@ impl<'a, W, P> Truncate<'a, W, P> {
             multiline: self.multiline,
             priority: self.priority,
             suffix: Some(suff),
+            success: false,
         }
     }
 }
@@ -176,7 +182,16 @@ impl<'a, W, P> Truncate<'a, W, P> {
             multiline: self.multiline,
             suffix: self.suffix,
             priority,
+            success: false,
         }
+    }
+
+    /// Returns whether the most recent application of this `Truncate`
+    /// actually performed any truncation. Always `false` until the
+    /// `Truncate` has been applied via the `&mut Self` implementation
+    /// of [`TableOption`].
+    pub fn is_ok(&self) -> bool {
+        self.success
     }
 }
 
@@ -258,6 +273,7 @@ where
             priority: self.priority,
             suffix: self.suffix,
             width,
+            success: false,
         };
 
         let widths = truncate_total_width(records, cfg, widths, total, t);
@@ -268,6 +284,58 @@ where
 
     fn hint_change(&self) -> Option<Entity> {
         // NOTE: We properly set widths and heights so nothign got need reastimation
+        None
+    }
+}
+
+impl<W, P, R> TableOption<R, ColoredConfig, CompleteDimension> for &mut Truncate<'_, W, P>
+where
+    W: Measurement<Width> + Clone,
+    P: Peaker + Clone,
+    R: Records + ExactRecords + PeekableRecords + RecordsMut<String>,
+    for<'a> &'a R: Records,
+    for<'a> <<&'a R as Records>::Iter as IntoRecords>::Cell: Cell + AsRef<str>,
+{
+    fn change(self, records: &mut R, cfg: &mut ColoredConfig, dims: &mut CompleteDimension) {
+        self.success = false;
+
+        if records.count_rows() == 0 || records.count_columns() == 0 {
+            return;
+        }
+
+        let width = self.width.clone().measure(&*records, cfg);
+
+        dims.estimate(&*records, cfg);
+        let widths = dims.get_widths().expect("must be present");
+
+        let total = get_table_total_width(widths, cfg);
+        if total <= width {
+            return;
+        }
+
+        let original_widths: Vec<usize> = widths.to_vec();
+        let t = Truncate {
+            multiline: self.multiline,
+            priority: self.priority.clone(),
+            suffix: self.suffix.clone(),
+            width,
+            success: false,
+        };
+
+        let new_widths = truncate_total_width(records, cfg, widths, total, t);
+
+        // Only report success if cell column widths actually changed.
+        // The `total <= width` short-circuit above eliminates the obvious
+        // no-op case, but a request that's below `total` but at or below
+        // the minimum determined by borders/padding can still leave
+        // cell content untouched -- in which case `is_ok()` should stay
+        // false so callers can trust the API.
+        self.success = new_widths != original_widths;
+        dims.set_widths(new_widths);
+        dims.clear_height(); // TODO: Can be optimized -- we must know the proper height already since we did wrap
+    }
+
+    fn hint_change(&self) -> Option<Entity> {
         None
     }
 }

--- a/tabled/src/settings/width/wrap.rs
+++ b/tabled/src/settings/width/wrap.rs
@@ -48,6 +48,10 @@ pub struct Wrap<W = usize, P = PriorityNone> {
     width: W,
     keep_words: bool,
     priority: P,
+    /// Set to `true` after a wrap call that actually had to wrap content
+    /// (i.e. the requested width was below the current table total width).
+    /// Use [`Wrap::is_ok`] to query.
+    success: bool,
 }
 
 impl<W> Wrap<W> {
@@ -60,6 +64,7 @@ impl<W> Wrap<W> {
             width,
             keep_words: false,
             priority: PriorityNone::new(),
+            success: false,
         }
     }
 }
@@ -82,6 +87,7 @@ impl<W, P> Wrap<W, P> {
             width: self.width,
             keep_words: self.keep_words,
             priority,
+            success: false,
         }
     }
 
@@ -92,6 +98,21 @@ impl<W, P> Wrap<W, P> {
     pub fn keep_words(mut self, on: bool) -> Self {
         self.keep_words = on;
         self
+    }
+
+    /// Returns whether the most recent application of this `Wrap` actually
+    /// performed any wrapping. Always `false` until the `Wrap` has been
+    /// applied via the `&mut Self` implementation of [`TableOption`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let mut wrap = Width::wrap(80);
+    /// table.with(&mut wrap);
+    /// assert!(wrap.is_ok()); // true if the table was actually wrapped
+    /// ```
+    pub fn is_ok(&self) -> bool {
+        self.success
     }
 }
 
@@ -129,6 +150,7 @@ where
             keep_words: self.keep_words,
             priority: self.priority,
             width,
+            success: false,
         };
         let widths = wrap_total_width(records, cfg, widths, total, w);
 
@@ -138,6 +160,55 @@ where
     fn hint_change(&self) -> Option<Entity> {
         // NOTE: We need to recalculate heights
         // TODO: It's actually could be fixed; we sort of already have new strings
+        Some(Entity::Row(0))
+    }
+}
+
+impl<W, P, R> TableOption<R, ColoredConfig, CompleteDimension> for &mut Wrap<W, P>
+where
+    W: Measurement<Width> + Clone,
+    P: Peaker + Clone,
+    R: Records + ExactRecords + PeekableRecords + RecordsMut<String>,
+    for<'a> &'a R: Records,
+    for<'a> <<&'a R as Records>::Iter as IntoRecords>::Cell: Cell + AsRef<str>,
+{
+    fn change(self, records: &mut R, cfg: &mut ColoredConfig, dims: &mut CompleteDimension) {
+        self.success = false;
+
+        if records.count_rows() == 0 || records.count_columns() == 0 {
+            return;
+        }
+
+        let width = self.width.clone().measure(&*records, cfg);
+
+        dims.estimate(&*records, cfg);
+        let widths = dims.get_widths().expect("must be found");
+
+        let total = get_table_total_width(widths, cfg);
+        if width >= total {
+            return;
+        }
+
+        let original_widths: Vec<usize> = widths.to_vec();
+        let w = Wrap {
+            keep_words: self.keep_words,
+            priority: self.priority.clone(),
+            width,
+            success: false,
+        };
+        let new_widths = wrap_total_width(records, cfg, widths, total, w);
+
+        // Only report success if cell column widths actually changed.
+        // The `width >= total` short-circuit above eliminates the obvious
+        // no-op case, but a request that's below `total` but at or below
+        // the minimum determined by borders/padding can still leave
+        // cell content untouched -- in which case `is_ok()` should stay
+        // false so callers can trust the API.
+        self.success = new_widths != original_widths;
+        dims.set_widths(new_widths);
+    }
+
+    fn hint_change(&self) -> Option<Entity> {
         Some(Entity::Row(0))
     }
 }

--- a/tabled/tests/settings/width_test.rs
+++ b/tabled/tests/settings/width_test.rs
@@ -1,8 +1,11 @@
 #![cfg(feature = "std")]
 #![cfg(feature = "assert")]
 
+use std::iter::FromIterator;
+
 use tabled::{
     assert::{assert_width, test_table},
+    builder::Builder,
     settings::{
         formatting::{TabSize, TrimStrategy},
         object::{Columns, Object, Rows, Segment},
@@ -2082,6 +2085,77 @@ test_table!(
     "| xxxx. xx xxxxxxxx xx xx xxxxxxxxxx   |"
     "+--------------------------------------+"
 );
+
+#[test]
+fn wrap_is_ok_true_when_wrap_needed() {
+    // 3x3 markdown table is wider than 5 columns total.
+    let mut table = Matrix::new(3, 3).with(Style::markdown());
+    let mut wrap = Width::wrap(5);
+    table.with(&mut wrap);
+    assert!(
+        wrap.is_ok(),
+        "expected wrap to report success when wrapping was needed"
+    );
+}
+
+#[test]
+fn wrap_is_ok_false_when_table_already_fits() {
+    let mut table = Matrix::new(3, 3).with(Style::markdown());
+    let mut wrap = Width::wrap(500);
+    table.with(&mut wrap);
+    assert!(
+        !wrap.is_ok(),
+        "expected wrap to NOT report success when table already fits"
+    );
+}
+
+#[test]
+fn truncate_is_ok_true_when_truncate_needed() {
+    let mut table = Matrix::new(3, 3).with(Style::markdown());
+    let mut truncate = Width::truncate(5);
+    table.with(&mut truncate);
+    assert!(truncate.is_ok());
+}
+
+#[test]
+fn truncate_is_ok_false_when_table_already_fits() {
+    let mut table = Matrix::new(3, 3).with(Style::markdown());
+    let mut truncate = Width::truncate(500);
+    table.with(&mut truncate);
+    assert!(!truncate.is_ok());
+}
+
+#[test]
+fn wrap_is_ok_false_when_request_below_minimum_borders_padding() {
+    // A request below the table's minimum (determined by borders/padding,
+    // not cell content) shouldn't report success because no cell content
+    // is actually wrapped. The request width 1 is less than the rendered
+    // width but the column widths are already at their floor.
+    let mut table = Builder::from_iter([[""]])
+        .build()
+        .with(Style::modern())
+        .clone();
+    let mut wrap = Width::wrap(1);
+    table.with(&mut wrap);
+    assert!(
+        !wrap.is_ok(),
+        "wrap should not report success when no cell content actually changes"
+    );
+}
+
+#[test]
+fn truncate_is_ok_false_when_request_below_minimum_borders_padding() {
+    let mut table = Builder::from_iter([[""]])
+        .build()
+        .with(Style::modern())
+        .clone();
+    let mut truncate = Width::truncate(1);
+    table.with(&mut truncate);
+    assert!(
+        !truncate.is_ok(),
+        "truncate should not report success when no cell content actually changes"
+    );
+}
 
 #[cfg(feature = "derive")]
 mod derived {


### PR DESCRIPTION
## Summary

Adds a way for callers to detect whether `Width::wrap` or `Width::truncate` actually had to do anything, without manually checking `grid.total_width` after the fact.

Closes #186

## Why this matters

Issue #186 noted that today users have to compare `grid.total_width` before and after to know whether wrapping/truncation actually happened. The maintainer's suggestion in the issue body was to add a flag to the struct and `impl TableOption on &mut`, exposing the result via something like `wrap.is_ok()`. This PR implements that pattern for both `Wrap` and `Truncate`.

```rust
let mut wrap = Width::wrap(80);
table.with(&mut wrap);
if wrap.is_ok() {
    // table actually got wrapped
}
```

## Changes

- `tabled/src/settings/width/wrap.rs`: added `success: bool` field to `Wrap`, `is_ok()` accessor, and a new `TableOption` impl for `&mut Wrap<W, P>` that mirrors the existing owned impl.
- `tabled/src/settings/width/truncate.rs`: same shape for `Truncate`.
- `tabled/tests/settings/width_test.rs`: 6 tests covering the work-needed path, the already-fits path, and the no-op edge case where the request is below the table's minimum (borders/padding floor) and no cell content actually changes.

The existing owned-value `TableOption` impls and call sites are untouched. The new `&mut` impls are purely additive.

## Self-review notes

Two things from a self-review pass that aren't obvious from the diff:

- **`Clone` bounds on the new impls.** The new `&mut` impls clone `self.width.clone()` and `self.priority.clone()` so they can construct a one-shot owned `Wrap` / `Truncate` to feed into the existing `wrap_total_width` / `truncate_total_width` helpers. The `Measurement` and `Peaker` traits are already `Clone` for the standard implementations (`PriorityNone`, `PriorityMax`, `PriorityMin`), so this didn't tighten the bound for any in-tree call site.

- **`is_ok()` only reflects real work, not "below total width".** A naive implementation could set `success = true` whenever the requested width is below the rendered total, but that misclassifies the case where the table's minimum is determined by borders/padding rather than cell content -- in which case no cell text changes. The implementation now compares column widths before and after `wrap_total_width` / `truncate_total_width` and only marks success when they actually differ. The two `*_below_minimum_borders_padding` tests assert this with a `Builder::from_iter([[""]]).build().with(Style::modern())` table and `Width::wrap(1)` / `Width::truncate(1)` -- the rendered output is unchanged and `is_ok()` correctly returns `false`.

## Testing

```
$ cargo build --workspace
ok

$ cargo test --package tabled --test main -- wrap truncate
running 64 tests
... (all pass) ...
test result: ok. 64 passed; 0 failed; 0 ignored

$ cargo test --package tabled --test main -- wrap_is_ok truncate_is_ok
running 6 tests
test settings::width_test::wrap_is_ok_true_when_wrap_needed                              ... ok
test settings::width_test::wrap_is_ok_false_when_table_already_fits                      ... ok
test settings::width_test::wrap_is_ok_false_when_request_below_minimum_borders_padding   ... ok
test settings::width_test::truncate_is_ok_true_when_truncate_needed                      ... ok
test settings::width_test::truncate_is_ok_false_when_table_already_fits                  ... ok
test settings::width_test::truncate_is_ok_false_when_request_below_minimum_borders_padding ... ok

$ cargo fmt --check
clean
```

This contribution was developed with AI assistance (Codex).
