### PR TITLE
switch file that table_width_2 example uses

### DIFF
--- a/tabled/examples/table_width_2.rs
+++ b/tabled/examples/table_width_2.rs
@@ -4,7 +4,7 @@ use tabled::{
 };
 
 fn main() {
-    let readme_text = include_str!("../../CHANGELOG.md");
+    let readme_text = include_str!("../README.md");
     let lines = readme_text.lines().filter(|s| !s.is_empty()).enumerate();
 
     let mut table = Table::new(lines);


### PR DESCRIPTION
 from ../../CHANGELOG.md to ../README.md, so that it doesn't point outside the crate structure.
 
 Based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/tabled/debian/patches/fix-missing-datafile-in-example.patch
 
 As we are trying to run the testsuite when packaging this in Debian.