### PR TITLE
feat(charset): make CleanCharset a builder with tab_size

### DIFF
--- a/tabled/src/settings/formatting/charset.rs
+++ b/tabled/src/settings/formatting/charset.rs
@@ -38,7 +38,7 @@ impl Charset {
     ///
     /// [`TabSize`]: crate::settings::formatting::TabSize
     pub fn clean() -> CleanCharset {
-        CleanCharset
+        CleanCharset { tab_size: None }
     }
 }
 
@@ -72,9 +72,34 @@ impl Charset {
 /// )
 /// ```
 #[derive(Debug, Default, Clone)]
-pub struct CleanCharset;
+pub struct CleanCharset {
+    tab_size: Option<usize>,
+}
 
 impl CleanCharset {
+    /// Replace `\t` with `size` spaces in the same pass that strips other control characters.
+    ///
+    /// By default, `\t` is dropped (no replacement). Setting a tab size makes a single
+    /// `Charset::clean().tab_size(N)` call equivalent to `TabSize::new(N)` followed by
+    /// `Charset::clean()`, but with one allocation and one pass per cell.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tabled::{Table, settings::formatting::Charset};
+    ///
+    /// let text = "Some\ttext\r";
+    ///
+    /// let mut table = Table::new([text]);
+    /// table.with(Charset::clean().tab_size(4));
+    ///
+    /// assert!(table.to_string().contains("Some    text"));
+    /// ```
+    pub fn tab_size(mut self, size: usize) -> Self {
+        self.tab_size = Some(size);
+        self
+    }
+
     /// Removes all symbols which may break the layout such as `\t`, `\r` and more.
     ///
     /// Notice that tab is just removed rather then being replaced with spaces.
@@ -90,7 +115,7 @@ impl CleanCharset {
     /// )
     /// ```
     pub fn clean(s: &str) -> Cow<'_, str> {
-        Cow::Owned(clean_charset(s))
+        Cow::Owned(clean_charset(s, None))
     }
 }
 
@@ -105,7 +130,7 @@ where
             for col in 0..records.count_columns() {
                 let pos = Position::new(row, col);
                 let text = records.get_text(pos);
-                let text = clean_charset(text);
+                let text = clean_charset(text, self.tab_size);
                 records.set(pos, text);
             }
         }
@@ -121,14 +146,29 @@ where
         let count_cols = records.count_columns();
         for pos in entity.iter(count_rows, count_cols) {
             let text = records.get_text(pos);
-            let text = clean_charset(text);
+            let text = clean_charset(text, self.tab_size);
             records.set(pos, text);
         }
     }
 }
 
-fn clean_charset(text: &str) -> String {
+fn clean_charset(text: &str, tab_size: Option<usize>) -> String {
     // It's enough for covering '\t' and '\r'
     // as well as a list of other unwanted escapes.
-    text.replace(|c| c != '\n' && c < ' ', "")
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '\t' => {
+                if let Some(n) = tab_size {
+                    for _ in 0..n {
+                        out.push(' ');
+                    }
+                }
+            }
+            '\n' => out.push(c),
+            c if c < ' ' => {}
+            _ => out.push(c),
+        }
+    }
+    out
 }

--- a/tabled/tests/settings/formatting_test.rs
+++ b/tabled/tests/settings/formatting_test.rs
@@ -3,11 +3,35 @@
 
 use tabled::{
     assert::test_table,
-    settings::{formatting::Justification, object::Columns, Color, Modify},
+    settings::{
+        formatting::{Charset, Justification},
+        object::Columns,
+        Color, Modify,
+    },
     Table,
 };
 
 use crate::util::Matrix;
+
+test_table!(
+    charset_clean_with_tab_size,
+    Table::new(["Some\ttext\r"]).with(Charset::clean().tab_size(4)),
+    "+--------------+"
+    "| &str         |"
+    "+--------------+"
+    "| Some    text |"
+    "+--------------+"
+);
+
+test_table!(
+    charset_clean_without_tab_size_unchanged,
+    Table::new(["Some\ttext\r"]).with(Charset::clean()),
+    "+----------+"
+    "| &str     |"
+    "+----------+"
+    "| Sometext |"
+    "+----------+"
+);
 
 test_table!(
     justification,


### PR DESCRIPTION
## Summary

Closes #497.

`Charset::clean()` and `TabSize::new()` currently each iterate every cell text once, so combining them allocates twice and walks the string twice. This PR adds an optional `tab_size(N)` builder method to `CleanCharset` so `Charset::clean().tab_size(4)` does both substitutions in a single pass.

The existing `Charset::clean()` and `TabSize::new()` remain unchanged for backward compatibility. Removing or deprecating `TabSize` is intentionally out of scope; the issue asked to make `Charset` capable of doing the work in one pass, which is now true.

## Diff

`tabled/src/settings/formatting/charset.rs`:
- Replaces the unit struct `pub struct CleanCharset;` with `pub struct CleanCharset { tab_size: Option<usize> }`. `Default, Clone, Debug` derives preserved.
- Adds a builder method:
  ```rust
  pub fn tab_size(mut self, size: usize) -> Self {
      self.tab_size = Some(size);
      self
  }
  ```
- Refactors `clean_charset` to take `tab_size: Option<usize>` and walk the string once, replacing `\t` with N spaces when set (otherwise dropping the tab as before).
- The static helper `CleanCharset::clean(&str) -> Cow<'_, str>` continues to work and now calls `clean_charset(s, None)`.

`tabled/tests/settings/formatting_test.rs`:
- Two new `test_table!` cases:
  - `charset_clean_with_tab_size`: `Charset::clean().tab_size(4)` against `"Some\ttext\r"` produces `"Some    text"` (tabs replaced, `\r` dropped).
  - `charset_clean_without_tab_size_unchanged`: `Charset::clean()` against the same input still produces `"Sometext"` (existing behavior).

## Verification

- `cargo fmt --all --check` clean.
- `cargo clippy --workspace --all-features -- -D warnings` clean.
- `cargo test --package tabled --all-features --tests` 966 passed, 0 failed.

## Test plan

- [x] `cargo test` passes locally.
- [x] `cargo clippy` clean.
- [x] No public API removed; existing `TabSize` still works.
- [ ] CI green on this PR.