### PR TITLE
fix build on docs.rs: `doc_auto_cfg` merged with `doc_cfg`

### DIFF
--- a/tabled/src/lib.rs
+++ b/tabled/src/lib.rs
@@ -254,7 +254,7 @@
 //! [`tabled::settings`]: crate::settings
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/zhiburt/tabled/86ac146e532ce9f7626608d7fd05072123603a2e/assets/tabled-gear.svg"
 )]


### PR DESCRIPTION
The `doc_auto_cfg` feature has been merged with `doc_cfg`. https://github.com/rust-lang/rust/pull/138907

It might be worth setting up an action running `cargo docs-rs` to detect this sort of issues in CI. See https://github.com/syphar/cargo-docs-rs