### PR TITLE
tabled_derive: drop proc-macro-error2, use syn::Error for diagnostics

### DIFF
--- a/tabled_derive/Cargo.toml
+++ b/tabled_derive/Cargo.toml
@@ -15,4 +15,3 @@ syn = { version = "2", features = ["full", "visit-mut", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 heck = "0.5"
-proc-macro-error2 = "2.0.1"

--- a/tabled_derive/src/error.rs
+++ b/tabled_derive/src/error.rs
@@ -52,18 +52,17 @@ impl std::fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-pub fn abort(err: Error) -> ! {
-    match err {
-        Error::Syn(err) => {
-            proc_macro_error2::abort! {err.span(), "{}", err}
+impl Error {
+    pub fn into_syn(self) -> syn::Error {
+        match self {
+            Error::Syn(err) => err,
+            Error::Custom { span, error, help } => {
+                let mut err = syn::Error::new(span, error);
+                if let Some(help) = help {
+                    err.combine(syn::Error::new(span, format!("help: {help}")));
+                }
+                err
+            }
         }
-        Error::Custom { span, error, help } => match help {
-            Some(help) => {
-                proc_macro_error2::abort! {span, "{}",  error; help="{}", help}
-            }
-            None => {
-                proc_macro_error2::abort! {span, "{}",  error}
-            }
-        },
     }
 }

--- a/tabled_derive/src/lib.rs
+++ b/tabled_derive/src/lib.rs
@@ -12,7 +12,6 @@ mod parse;
 
 use attributes::FormatArg;
 use proc_macro2::TokenStream;
-use proc_macro_error2::proc_macro_error;
 use quote::{quote, ToTokens, TokenStreamExt};
 use std::{collections::HashMap, str};
 use syn::spanned::Spanned;
@@ -28,26 +27,20 @@ use crate::error::Error;
 type FieldNameFn = fn(usize, &Field) -> TokenStream;
 
 #[proc_macro_derive(Tabled, attributes(tabled))]
-#[proc_macro_error]
 pub fn tabled(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let ast = impl_tabled(&input);
-    proc_macro::TokenStream::from(ast)
+    impl_tabled(&input)
+        .unwrap_or_else(|e| e.into_syn().into_compile_error())
+        .into()
 }
 
-fn impl_tabled(ast: &DeriveInput) -> TokenStream {
-    let attrs = TypeAttributes::parse(&ast.attrs)
-        .map_err(error::abort)
-        .unwrap();
+fn impl_tabled(ast: &DeriveInput) -> Result<TokenStream, Error> {
+    let attrs = TypeAttributes::parse(&ast.attrs)?;
 
-    let tabled_trait_path = get_crate_name_expr(&attrs).map_err(error::abort).unwrap();
+    let tabled_trait_path = get_crate_name_expr(&attrs)?;
 
-    let length = get_tabled_length(ast, &attrs, &tabled_trait_path)
-        .map_err(error::abort)
-        .unwrap();
-    let info = collect_info(ast, &attrs, &tabled_trait_path)
-        .map_err(error::abort)
-        .unwrap();
+    let length = get_tabled_length(ast, &attrs, &tabled_trait_path)?;
+    let info = collect_info(ast, &attrs, &tabled_trait_path)?;
     let fields = info.values;
     let headers = info.headers;
 
@@ -68,7 +61,7 @@ fn impl_tabled(ast: &DeriveInput) -> TokenStream {
         }
     };
 
-    expanded
+    Ok(expanded)
 }
 
 fn get_tabled_length(


### PR DESCRIPTION
Resolves #583