### PR TITLE
fix(papergrid): saturating_sub in calculate_indent to avoid underflow panic

### DIFF
--- a/papergrid/src/grid/peekable.rs
+++ b/papergrid/src/grid/peekable.rs
@@ -441,7 +441,7 @@ mod grid_basic {
     }
 
     fn calculate_indent(alignment: AlignmentHorizontal, width: usize, available: usize) -> HIndent {
-        let diff = available - width;
+        let diff = available.saturating_sub(width);
 
         let (left, right) = match alignment {
             AlignmentHorizontal::Left => (0, diff),
@@ -982,7 +982,7 @@ mod grid_not_spanned {
     }
 
     fn calculate_indent(alignment: AlignmentHorizontal, width: usize, available: usize) -> HIndent {
-        let diff = available - width;
+        let diff = available.saturating_sub(width);
 
         let (left, right) = match alignment {
             AlignmentHorizontal::Left => (0, diff),
@@ -1858,7 +1858,7 @@ mod grid_spanned {
     }
 
     fn calculate_indent(alignment: AlignmentHorizontal, width: usize, available: usize) -> HIndent {
-        let diff = available - width;
+        let diff = available.saturating_sub(width);
 
         let (left, right) = match alignment {
             AlignmentHorizontal::Left => (0, diff),

--- a/papergrid/tests/grid/peekable_grid.rs
+++ b/papergrid/tests/grid/peekable_grid.rs
@@ -237,3 +237,79 @@ test_table!(
     "|is a library     |is a library|is a library    |is a library|"
     "+-----------------+------------+----------------+------------+"
 );
+
+#[test]
+fn does_not_panic_when_dimension_width_is_less_than_content_width() {
+    // Regression test for https://github.com/zhiburt/tabled/issues/567
+    //
+    // A custom `Dimension` implementation is allowed to report a column
+    // width smaller than the actual content width (e.g. a heuristic that
+    // estimates width ahead of a resize). `calculate_indent` used to do an
+    // unchecked `available - width` subtraction, which panics with
+    // "attempt to subtract with overflow" in that case.
+    let data = [["hello world"]];
+    let data = data
+        .iter()
+        .map(|row| row.iter().map(Text::new).collect())
+        .collect();
+
+    let records = VecRecords::new(data);
+    let cfg = SpannedConfig::default();
+
+    let dims = Dims {
+        width: vec![1],
+        height: vec![1],
+    };
+
+    let _ = PeekableGrid::new(&records, &cfg, &dims, NoColors).to_string();
+}
+
+#[test]
+fn does_not_panic_when_dimension_width_is_less_than_content_width_not_spanned_path() {
+    // Regression test for https://github.com/zhiburt/tabled/issues/567
+    //
+    // Same root cause as `does_not_panic_when_dimension_width_is_less_than_content_width`,
+    // but forces the `grid_not_spanned` code path (the exact module/line the
+    // issue's backtrace pointed at) by setting a justification, which makes
+    // `is_basic` false in `print_grid`.
+    let data = [["hello world"]];
+    let data = data
+        .iter()
+        .map(|row| row.iter().map(Text::new).collect())
+        .collect();
+
+    let records = VecRecords::new(data);
+    let mut cfg = SpannedConfig::default();
+    cfg.set_justification((0, 0).into(), '.');
+
+    let dims = Dims {
+        width: vec![1],
+        height: vec![1],
+    };
+
+    let _ = PeekableGrid::new(&records, &cfg, &dims, NoColors).to_string();
+}
+
+#[test]
+fn does_not_panic_when_dimension_width_is_less_than_content_width_spanned_path() {
+    // Regression test for https://github.com/zhiburt/tabled/issues/567
+    //
+    // Same root cause, forcing the `grid_spanned` code path by setting a
+    // column span so `has_column_spans()` is true.
+    let data = [["hello world", "b"]];
+    let data = data
+        .iter()
+        .map(|row| row.iter().map(Text::new).collect())
+        .collect();
+
+    let records = VecRecords::new(data);
+    let mut cfg = SpannedConfig::default();
+    cfg.set_column_span((0, 0).into(), 2);
+
+    let dims = Dims {
+        width: vec![1, 1],
+        height: vec![1],
+    };
+
+    let _ = PeekableGrid::new(&records, &cfg, &dims, NoColors).to_string();
+}


### PR DESCRIPTION
`calculate_indent()` panics with "attempt to subtract with overflow" when a custom `Dimension::get_width` returns a width smaller than the content width, because it does an unchecked `available - width`.

The function is duplicated in three private grid modules, and all three had the same unchecked subtraction (peekable.rs:444, 985, 1861). Each now uses `available.saturating_sub(width)`. Clamping to 0 is the correct indent when content already exceeds the reported available width.

Added regression tests driving a custom `Dimension` whose width is less than the content width. They panic without the fix (at all three sites) and pass with it. `cargo test -p papergrid` green, clippy and fmt clean.

Note: the adjacent `rest_width = cell_width - line_width` a few lines above each site is intentionally left as-is. It is not affected by this bug: `cell_width` is `get_width` (the max over the cell's lines) and `line_width` is a single line's width, so `cell_width >= line_width` holds by construction.

Closes #567
